### PR TITLE
feat(planner): include stage1 error metadata

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -119,6 +119,7 @@ function App() {
         stage2: null,
         stage3: null,
         metadata: null,
+        errors: [],
         loading: {
           stage1: false,
           stage2: false,
@@ -153,6 +154,16 @@ function App() {
               // Ensure stage1 is an array
               if (!Array.isArray(lastMsg.stage1)) lastMsg.stage1 = [];
               lastMsg.stage1.push(event.data);
+              return { ...prev, messages };
+            });
+            break;
+
+          case 'stage1_error':
+            setCurrentConversation((prev) => {
+              const messages = [...prev.messages];
+              const lastMsg = messages[messages.length - 1];
+              if (!Array.isArray(lastMsg.errors)) lastMsg.errors = [];
+              lastMsg.errors.push(event.data);
               return { ...prev, messages };
             });
             break;
@@ -236,7 +247,22 @@ function App() {
             break;
 
           case 'error':
-            console.error('Stream error:', event.message);
+            console.error('Stream error:', event.error);
+            setCurrentConversation((prev) => {
+              const messages = [...prev.messages];
+              const lastMsg = messages[messages.length - 1];
+              if (!Array.isArray(lastMsg.errors)) lastMsg.errors = [];
+              lastMsg.errors.push({
+                model: 'system',
+                error: event.error || 'Unknown error',
+              });
+              if (lastMsg.loading) {
+                lastMsg.loading.stage1 = false;
+                lastMsg.loading.stage2 = false;
+                lastMsg.loading.stage3 = false;
+              }
+              return { ...prev, messages };
+            });
             setIsLoading(false);
             break;
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -50,7 +50,15 @@ export const api = {
       headers: getAuthHeaders()
     });
     if (!response.ok) {
-      throw new Error('Failed to fetch models');
+      let detail = 'Failed to fetch models';
+      try {
+        const data = await response.json();
+        detail = data.detail || data.error || detail;
+      } catch (error) {
+        const text = await response.text();
+        if (text) detail = text;
+      }
+      throw new Error(detail);
     }
     return response.json();
   },

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -170,6 +170,30 @@
   font-size: 14px;
 }
 
+.stage-error-panel {
+  margin: 12px 0;
+  padding: 12px 16px;
+  background: var(--md-sys-color-error-container);
+  border-radius: 12px;
+  color: var(--md-sys-color-on-error-container);
+  border: 1px solid var(--md-sys-color-error);
+  font-size: 13px;
+}
+
+.stage-error-title {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.stage-error-list {
+  margin: 0;
+  padding-left: 16px;
+}
+
+.stage-error-list li {
+  margin-bottom: 4px;
+}
+
 .spinner {
   width: 20px;
   height: 20px;

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -134,6 +134,19 @@ export default function ChatInterface({
                 <div className="assistant-message">
                   <div className="message-label">LLM Council</div>
 
+                  {msg.errors && msg.errors.length > 0 && (
+                    <div className="stage-error-panel">
+                      <div className="stage-error-title">Model errors</div>
+                      <ul className="stage-error-list">
+                        {msg.errors.map((error, errorIndex) => (
+                          <li key={errorIndex}>
+                            <strong>{error.model}:</strong> {error.error}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
                   {/* Stage 1 */}
                   {msg.loading?.stage1 && (
                     <div className="stage-loading">

--- a/frontend/src/components/ModelSelect.css
+++ b/frontend/src/components/ModelSelect.css
@@ -29,6 +29,16 @@
     border-color: var(--md-sys-color-on-surface);
 }
 
+.model-select-trigger.disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    border-color: var(--md-sys-color-outline-variant);
+}
+
+.model-select-trigger.disabled:hover {
+    border-color: var(--md-sys-color-outline-variant);
+}
+
 .selected-tags {
     display: flex;
     flex-wrap: wrap;

--- a/frontend/src/components/ModelSelect.jsx
+++ b/frontend/src/components/ModelSelect.jsx
@@ -7,7 +7,8 @@ const ModelSelect = ({
     onChange,
     label,
     multi = false,
-    maxSelected = 5
+    maxSelected = 5,
+    disabled = false
 }) => {
     const [isOpen, setIsOpen] = useState(false);
     const [search, setSearch] = useState('');
@@ -41,6 +42,12 @@ const ModelSelect = ({
             setHoveredModel(null);
         }
     }, [isOpen]);
+
+    useEffect(() => {
+        if (disabled) {
+            setIsOpen(false);
+        }
+    }, [disabled]);
 
     const filteredOptions = options.filter(option =>
         option.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -88,8 +95,10 @@ const ModelSelect = ({
         <div className="model-select-container" ref={wrapperRef}>
             <label>{label}</label>
             <div
-                className="model-select-trigger"
-                onClick={() => setIsOpen(!isOpen)}
+                className={`model-select-trigger ${disabled ? 'disabled' : ''}`}
+                onClick={() => {
+                    if (!disabled) setIsOpen(!isOpen);
+                }}
             >
                 {getDisplayValue()}
                 <span className="arrow">▼</span>
@@ -113,6 +122,7 @@ const ModelSelect = ({
                         onChange={(e) => setSearch(e.target.value)}
                         onClick={(e) => e.stopPropagation()}
                         autoFocus
+                        disabled={disabled}
                     />
                     <div className="model-options">
                         {filteredOptions.length > 0 ? (

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -299,3 +299,12 @@
   font-size: 14px;
   opacity: 0.7;
 }
+
+.model-error {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--md-sys-color-error-container);
+  color: var(--md-sys-color-on-error-container);
+  font-size: 12px;
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -9,6 +9,7 @@ const Sidebar = ({ conversations, currentConversationId, onSelectConversation, o
   const [chairmanModel, setChairmanModel] = useState('');
   const [councilModels, setCouncilModels] = useState([]);
   const [loadingModels, setLoadingModels] = useState(false);
+  const [modelsError, setModelsError] = useState(null);
   const [status, setStatus] = useState(null);
   const [statusError, setStatusError] = useState(null);
   const [showAllHistory, setShowAllHistory] = useState(false);
@@ -36,6 +37,7 @@ const Sidebar = ({ conversations, currentConversationId, onSelectConversation, o
   const loadModels = async () => {
     setLoadingModels(true);
     try {
+      setModelsError(null);
       const data = await api.getModels();
       setModels(data);
       // Set defaults? Or leave empty to use backend defaults
@@ -43,6 +45,7 @@ const Sidebar = ({ conversations, currentConversationId, onSelectConversation, o
       // Let's leave empty and let user know "Default" is used if empty
     } catch (error) {
       console.error("Failed to load models", error);
+      setModelsError(error.message || "Failed to load models");
     } finally {
       setLoadingModels(false);
     }
@@ -139,6 +142,7 @@ const Sidebar = ({ conversations, currentConversationId, onSelectConversation, o
             value={chairmanModel}
             onChange={setChairmanModel}
             multi={false}
+            disabled={loadingModels || !!modelsError}
           />
 
           <ModelSelect
@@ -148,7 +152,13 @@ const Sidebar = ({ conversations, currentConversationId, onSelectConversation, o
             onChange={setCouncilModels}
             multi={true}
             maxSelected={5}
+            disabled={loadingModels || !!modelsError}
           />
+          {modelsError && (
+            <div className="model-error">
+              {modelsError}
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Surface per-model failures from Stage 1 so the UI can show actionable reasons (permission, unsupported params, missing API key).
- Make the council run resilient by collecting and reporting model-level errors and aborting gracefully when no models succeed.
- Propagate OpenRouter/backend error details to clients so the model selector can be disabled and show the failure reason.
- Improve diagnosability of OpenRouter requests by sending expected headers and extracting clearer error messages.

### Description
- Collect and return per-model Stage 1 errors via a `stage1_errors` field added to the council `metadata` and return tuple forms from `stage1` helpers.  (changes in `backend/council.py`).
- Update streaming behavior to emit `stage1_error` SSE events during Stage 1 and emit an `error` event / abort the stream when all selected models fail. (changes in `backend/main.py`).
- Improve OpenRouter integration by sending `Authorization` and `HTTP-Referer` headers, adding `_extract_error_message` to surface clearer messages, and returning structured error objects from `query_model`/`query_model_stream`/`fetch_models`. (changes in `backend/openrouter.py`).
- Surface backend `/api/models` error detail, surface Stage 1 errors in the UI, disable model selection when model list fetch fails, and add styles for error panels/disabled controls. (changes across `frontend/src/*`).

### Testing
- Ran `PYTHONPATH=/workspace/llm-council python tests/check_syntax.py` and import completed successfully.
- Ran `pytest` and all tests passed (`11 passed`).
- Launched the backend and ran `python tests/verify_delete.py` against the running server and it succeeded.
- Frontend dev server launched and a UI screenshot was captured to verify the model-list error state (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee06ad4208322ae00bd55ea7256fa)