### PR TITLE
feat(planner): stabilize auth context and storage fallback

### DIFF
--- a/backend/storage.py
+++ b/backend/storage.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from sqlalchemy.future import select
 from sqlalchemy import update
 from sqlalchemy.orm.attributes import flag_modified
-from .config import DATA_DIR, DATABASE_URL, APP_ORIGIN
+from .config import DATA_DIR, APP_ORIGIN
 from .database import AsyncSessionLocal, ConversationModel, init_db
 
 # --- Database Storage Helpers ---
@@ -194,25 +194,25 @@ def file_list_conversations(user_id: str) -> List[Dict[str, Any]]:
 # This means we need to refactor `main.py` to `await` storage calls.
 
 async def create_conversation(conversation_id: str, user_id: str, framework: str = "standard", council_models: list = None, chairman_model: str = None):
-    if DATABASE_URL:
+    if os.getenv("DATABASE_URL"):
         return await db_create_conversation(user_id, conversation_id, framework, council_models, chairman_model)
     else:
         return file_create_conversation(conversation_id, user_id, framework, council_models, chairman_model)
 
 async def get_conversation(conversation_id: str, user_id: str):
-    if DATABASE_URL:
+    if os.getenv("DATABASE_URL"):
         return await db_get_conversation(conversation_id, user_id)
     else:
         return file_get_conversation(conversation_id, user_id)
 
 async def list_conversations(user_id: str):
-    if DATABASE_URL:
+    if os.getenv("DATABASE_URL"):
         return await db_list_conversations(user_id)
     else:
         return file_list_conversations(user_id)
 
 async def add_user_message(conversation_id: str, user_id: str, content: str):
-    if DATABASE_URL:
+    if os.getenv("DATABASE_URL"):
         await db_add_message(conversation_id, user_id, {"role": "user", "content": content})
     else:
         # Fallback to file - read, update, save
@@ -228,7 +228,7 @@ async def add_assistant_message(conversation_id: str, user_id: str, stage1, stag
         "stage2": stage2,
         "stage3": stage3
     }
-    if DATABASE_URL:
+    if os.getenv("DATABASE_URL"):
         await db_add_message(conversation_id, user_id, message)
     else:
         conv = file_get_conversation(conversation_id, user_id)
@@ -237,7 +237,7 @@ async def add_assistant_message(conversation_id: str, user_id: str, stage1, stag
         file_save_conversation(conv)
 
 async def update_conversation_title(conversation_id: str, user_id: str, title: str):
-    if DATABASE_URL:
+    if os.getenv("DATABASE_URL"):
         await db_update_title(conversation_id, user_id, title)
     else:
         conv = file_get_conversation(conversation_id, user_id)
@@ -246,7 +246,7 @@ async def update_conversation_title(conversation_id: str, user_id: str, title: s
         file_save_conversation(conv)
 
 async def delete_conversation(conversation_id: str, user_id: str):
-    if DATABASE_URL:
+    if os.getenv("DATABASE_URL"):
         await db_delete_conversation(conversation_id, user_id)
     else:
         file_delete_conversation(conversation_id, user_id)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   background: var(--md-sys-color-background);
   color: var(--md-sys-color-on-background);
+  position: relative;
 }
 
 .main-content {
@@ -39,6 +40,24 @@
   /* Ensure it stays above content if needed */
 }
 
+.menu-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: transparent;
+  color: var(--md-sys-color-on-surface);
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.menu-btn:hover {
+  background: var(--md-sys-color-surface-container-high);
+}
+
 .logout-btn {
   padding: 6px 12px;
   background: transparent;
@@ -61,4 +80,35 @@
   height: 100vh;
   color: #666;
   font-size: 16px;
+}
+
+.sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  border: none;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 20;
+}
+
+@media (max-width: 900px) {
+  .user-header {
+    justify-content: space-between;
+    padding: 0 16px;
+  }
+
+  .menu-btn {
+    display: inline-flex;
+  }
+}
+
+@media (max-width: 600px) {
+  .user-header {
+    gap: 8px;
+    font-size: 12px;
+  }
+
+  .logout-btn {
+    padding: 6px 10px;
+    font-size: 11px;
+  }
 }

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -73,6 +73,28 @@
   .chat-header {
     padding: 16px;
   }
+
+  .header-actions {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 600px) {
+  .chat-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .export-btn {
+    width: 36px;
+    height: 36px;
+  }
 }
 
 .messages-container {

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GoogleLogin } from '@react-oauth/google';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../contexts/authContext';
 import { api } from '../api';
 import './Login.css';
 

--- a/frontend/src/components/ModelSelect.jsx
+++ b/frontend/src/components/ModelSelect.jsx
@@ -15,12 +15,14 @@ const ModelSelect = ({
     const [hoveredModel, setHoveredModel] = useState(null);
     const wrapperRef = useRef(null);
     const tooltipRef = useRef(null);
+    const isDropdownOpen = isOpen && !disabled;
 
     // Close dropdown when clicking outside
     useEffect(() => {
         function handleClickOutside(event) {
             if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
                 setIsOpen(false);
+                setHoveredModel(null);
             }
         }
         document.addEventListener("mousedown", handleClickOutside);
@@ -36,18 +38,10 @@ const ModelSelect = ({
         }
     }, [hoveredModel]);
 
-    // Clear hover when closed
-    useEffect(() => {
-        if (!isOpen) {
-            setHoveredModel(null);
-        }
-    }, [isOpen]);
-
-    useEffect(() => {
-        if (disabled) {
-            setIsOpen(false);
-        }
-    }, [disabled]);
+    const closeDropdown = () => {
+        setIsOpen(false);
+        setHoveredModel(null);
+    };
 
     const filteredOptions = options.filter(option =>
         option.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -65,7 +59,7 @@ const ModelSelect = ({
             }
         } else {
             onChange(option.id);
-            setIsOpen(false);
+            closeDropdown();
         }
     };
 
@@ -97,7 +91,13 @@ const ModelSelect = ({
             <div
                 className={`model-select-trigger ${disabled ? 'disabled' : ''}`}
                 onClick={() => {
-                    if (!disabled) setIsOpen(!isOpen);
+                    if (!disabled) {
+                        if (isOpen) {
+                            closeDropdown();
+                        } else {
+                            setIsOpen(true);
+                        }
+                    }
                 }}
             >
                 {getDisplayValue()}
@@ -112,7 +112,7 @@ const ModelSelect = ({
                 </div>
             )}
 
-            {isOpen && (
+            {isDropdownOpen && (
                 <div className="model-select-dropdown">
                     <input
                         type="text"
@@ -150,7 +150,7 @@ const ModelSelect = ({
             )}
 
             {/* Tooltip / Hover Card */}
-            {hoveredModel && (
+            {isDropdownOpen && hoveredModel && (
                 <div className="model-tooltip" ref={tooltipRef}>
                     <h3>{hoveredModel.name}</h3>
                     <p className="model-description">{hoveredModel.description || "No description available."}</p>

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -21,6 +21,23 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.sidebar-close-btn {
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: transparent;
+  color: var(--md-sys-color-on-surface);
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.sidebar-close-btn:hover {
+  background: var(--md-sys-color-surface-container-high);
 }
 
 .sidebar-header h2 {
@@ -198,7 +215,7 @@
 }
 
 /* List Styling */
-.conversation-list {
+.conversations-list {
   flex: 1;
   overflow-y: auto;
   padding: 0 12px 12px 12px;
@@ -307,4 +324,25 @@
   background: var(--md-sys-color-error-container);
   color: var(--md-sys-color-on-error-container);
   font-size: 12px;
+}
+
+@media (max-width: 900px) {
+  .sidebar.mobile {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: min(85vw, 320px);
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    z-index: 30;
+    box-shadow: var(--md-sys-elevation-level-3);
+  }
+
+  .sidebar.mobile.open {
+    transform: translateX(0);
+  }
+
+  .sidebar-header {
+    padding: 16px 16px 8px 16px;
+  }
 }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -3,7 +3,15 @@ import './Sidebar.css';
 import { api } from '../api';
 import ModelSelect from './ModelSelect';
 
-const Sidebar = memo(({ conversations, currentConversationId, onSelectConversation, onNewConversation }) => {
+const Sidebar = memo(({
+  conversations,
+  currentConversationId,
+  onSelectConversation,
+  onNewConversation,
+  isMobile,
+  isOpen,
+  onClose,
+}) => {
   const [selectedFramework, setSelectedFramework] = useState('standard');
   const [models, setModels] = useState([]);
   const [chairmanModel, setChairmanModel] = useState('');
@@ -76,7 +84,7 @@ const Sidebar = memo(({ conversations, currentConversationId, onSelectConversati
   };
 
   return (
-    <div className="sidebar">
+    <div className={`sidebar ${isMobile ? 'mobile' : ''} ${isOpen ? 'open' : ''}`}>
       <div className="sidebar-header">
         <div className="header-title-row">
           <h2>LLM Council</h2>
@@ -90,6 +98,16 @@ const Sidebar = memo(({ conversations, currentConversationId, onSelectConversati
             <div className="status-badge status-file" title="Failed to fetch backend status">
               OFFLINE
             </div>
+          )}
+          {isMobile && (
+            <button
+              type="button"
+              className="sidebar-close-btn"
+              onClick={onClose}
+              aria-label="Close navigation"
+            >
+              ×
+            </button>
           )}
         </div>
 

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,50 +1,14 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
-import { googleLogout, useGoogleLogin } from '@react-oauth/google';
-import { api } from '../api';
-
-const AuthContext = createContext(null);
+import React, { useState } from 'react';
+import { googleLogout } from '@react-oauth/google';
+import { AuthContext } from './authContext';
 
 export const AuthProvider = ({ children }) => {
-    const [user, setUser] = useState(null);
-    const [token, setToken] = useState(localStorage.getItem('auth_token'));
-    const [isLoading, setIsLoading] = useState(true);
-
-    useEffect(() => {
-        // If we have a token, we consider the user logged in for now,
-        // but in a real app we might validate it or fetch user profile on load.
-        // For simplicity, we just rely on the presence of the token.
-        if (token) {
-            // Ideally we would decode the token or fetch /me, but we stored user in localStorage too?
-            // Let's store user info in localStorage for persistence across reloads
-            const storedUser = localStorage.getItem('auth_user');
-            if (storedUser) {
-                setUser(JSON.parse(storedUser));
-            }
-        }
-        setIsLoading(false);
-    }, [token]);
-
-    const login = useGoogleLogin({
-        onSuccess: async (tokenResponse) => {
-            try {
-                // Exchange Google ID token for session JWT
-                // Note: useGoogleLogin with default flow gives 'access_token' (OAuth2). 
-                // But for ID token verification we usually want the 'credential' from the GIS button 
-                // OR we can use the 'id_token' flow if configured.
-                // However, standard flow is to send 'access_token' to backend which then calls Google UserInfo,
-                // OR send 'id_token'.
-                // Let's stick to the simplest: Use the GoogleLogin component (Button) which gives a credential (id_token).
-                // But useGoogleLogin hook gives an access_token by default unless flow: 'auth-code'.
-                // Wait, for @react-oauth/google, the <GoogleLogin> component returns a credential (JWT id_token).
-                // The useGoogleLogin hook returns a code or access_token.
-                // I will use `GoogleLogin` component in Login.jsx instead of the hook here for the initial sign-in.
-                // So this `login` helper might not be needed if we use the component directly.
-            } catch (error) {
-                console.error('Login failed:', error);
-            }
-        },
-        onError: error => console.log('Login Failed:', error)
+    const [token, setToken] = useState(() => localStorage.getItem('auth_token'));
+    const [user, setUser] = useState(() => {
+        const storedUser = localStorage.getItem('auth_user');
+        return storedUser ? JSON.parse(storedUser) : null;
     });
+    const isLoading = false;
 
     const handleLoginSuccess = (sessionData) => {
         setToken(sessionData.access_token);
@@ -67,5 +31,3 @@ export const AuthProvider = ({ children }) => {
         </AuthContext.Provider>
     );
 };
-
-export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/contexts/authContext.js
+++ b/frontend/src/contexts/authContext.js
@@ -1,0 +1,5 @@
+import { createContext, useContext } from 'react';
+
+export const AuthContext = createContext(null);
+
+export const useAuth = () => useContext(AuthContext);


### PR DESCRIPTION
### Motivation
- Fix lint failures caused by calling `setState` synchronously from effects and improve React fast-refresh compatibility.
- Make file-based storage fallback deterministic for tests by evaluating `DATABASE_URL` at runtime.
- Improve mobile navigation UX with a drawer overlay and explicit open/close controls to avoid awkward sidebar behavior.

### Description
- Refactored authentication context by adding `frontend/src/contexts/authContext.js` and updating `frontend/src/contexts/AuthContext.jsx` to avoid `setState` in effects and provide stable `AuthProvider` state consumption via `useAuth`.
- Updated `frontend/src/components/ModelSelect.jsx` to stop calling `setState` inside effects, introduced `closeDropdown` and `isDropdownOpen` gating, and ensured hover/tooltips are cleared when the dropdown closes.
- Implemented mobile drawer behavior and controls in `frontend/src/App.jsx` and `frontend/src/components/Sidebar.jsx`, and added responsive styles in `frontend/src/App.css`, `frontend/src/components/Sidebar.css`, and `frontend/src/components/ChatInterface.css` (overlay, menu/close buttons, and transitions).
- Made `backend/storage.py` check `os.getenv("DATABASE_URL")` at call time so the code falls back to file storage reliably during tests.

### Testing
- Ran `npm run lint` in `frontend` which completed without ESLint errors or blocking warnings.
- Ran `pytest` in the repository and all tests passed (`11 passed`).
- No additional unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f739463a4832287edf7d30fdeb623)