### PR TITLE
🧪 Improve parse_ranking_from_text reliability and coverage

### DIFF
--- a/backend/council.py
+++ b/backend/council.py
@@ -180,26 +180,33 @@ def parse_ranking_from_text(ranking_text: str) -> List[str]:
     """
     import re
 
-    # Look for "FINAL RANKING:" section
-    if "FINAL RANKING:" in ranking_text:
+    # Look for "FINAL RANKING:" section (case-insensitive)
+    marker = "FINAL RANKING:"
+    upper_text = ranking_text.upper()
+    marker_idx = upper_text.find(marker)
+
+    if marker_idx != -1:
         # Extract everything after "FINAL RANKING:"
-        parts = ranking_text.split("FINAL RANKING:")
-        if len(parts) >= 2:
-            ranking_section = parts[1]
-            # Try to extract numbered list format (e.g., "1. Response A")
-            # This pattern looks for: number, period, optional space, "Response X"
-            numbered_matches = re.findall(r'\d+\.\s*Response [A-Z]', ranking_section)
-            if numbered_matches:
-                # Extract just the "Response X" part
-                return [re.search(r'Response [A-Z]', m).group() for m in numbered_matches]
+        ranking_section = ranking_text[marker_idx + len(marker):]
+        # Try to extract numbered list format (e.g., "1. Response A")
+        # This pattern looks for: number, period, optional space, "Response X"
+        numbered_matches = re.findall(r'\d+\.\s*Response [A-Z]', ranking_section, re.IGNORECASE)
+        if numbered_matches:
+            # Extract and normalize the "Response X" part
+            results = []
+            for m in numbered_matches:
+                inner = re.search(r'Response\s+([A-Z])', m, re.IGNORECASE)
+                if inner:
+                    results.append(f"Response {inner.group(1).upper()}")
+            return results
 
-            # Fallback: Extract all "Response X" patterns in order
-            matches = re.findall(r'Response [A-Z]', ranking_section)
-            return matches
+        # Fallback: Extract all "Response X" patterns in order from the section
+        matches = re.findall(r'Response\s+([A-Z])', ranking_section, re.IGNORECASE)
+        return [f"Response {m.upper()}" for m in matches]
 
-    # Fallback: try to find any "Response X" patterns in order
-    matches = re.findall(r'Response [A-Z]', ranking_text)
-    return matches
+    # Fallback: try to find any "Response X" patterns in order in full text
+    matches = re.findall(r'Response\s+([A-Z])', ranking_text, re.IGNORECASE)
+    return [f"Response {m.upper()}" for m in matches]
 
 
 def calculate_aggregate_rankings(

--- a/tests/test_ranking_parser.py
+++ b/tests/test_ranking_parser.py
@@ -1,0 +1,70 @@
+import pytest
+from backend.council import parse_ranking_from_text
+
+def test_standard_ranking():
+    text = """
+    Evaluation of responses:
+    Response A is good.
+    Response B is okay.
+
+    FINAL RANKING:
+    1. Response A
+    2. Response B
+    """
+    assert parse_ranking_from_text(text) == ["Response A", "Response B"]
+
+def test_unnumbered_ranking_section():
+    text = """
+    FINAL RANKING:
+    Response B, Response A
+    """
+    assert parse_ranking_from_text(text) == ["Response B", "Response A"]
+
+def test_no_final_ranking_section():
+    text = "I prefer Response C over Response A and Response B."
+    assert parse_ranking_from_text(text) == ["Response C", "Response A", "Response B"]
+
+def test_extra_text_before_ranking():
+    text = """
+    Response A is first mentioned here.
+    Now the official part:
+    FINAL RANKING:
+    1. Response B
+    2. Response A
+    """
+    assert parse_ranking_from_text(text) == ["Response B", "Response A"]
+
+def test_no_matches():
+    text = "Everything was bad."
+    assert parse_ranking_from_text(text) == []
+
+def test_multiple_digits():
+    text = """
+    FINAL RANKING:
+    1. Response A
+    2. Response B
+    3. Response C
+    4. Response D
+    5. Response E
+    6. Response F
+    7. Response G
+    8. Response H
+    9. Response I
+    10. Response J
+    """
+    result = parse_ranking_from_text(text)
+    assert "Response J" in result
+    assert result[-1] == "Response J"
+
+def test_case_sensitivity():
+    text = """
+    final ranking:
+    1. response A
+    2. response B
+    """
+    # Verify that parsing is case-insensitive and normalizes to "Response X"
+    assert parse_ranking_from_text(text) == ["Response A", "Response B"]
+
+def test_varied_whitespace():
+    text = "FINAL RANKING: 1.Response A, 2.  Response B"
+    assert parse_ranking_from_text(text) == ["Response A", "Response B"]


### PR DESCRIPTION
This PR addresses the untested ranking parser in `backend/council.py`. 

### 🎯 What
The `parse_ranking_from_text` function, which is critical for the application's core feature of aggregating model rankings, was previously untested and sensitive to case and formatting variations.

### 📊 Coverage
The new test suite `tests/test_ranking_parser.py` covers:
- Standard well-formatted input (numbered list under "FINAL RANKING:").
- "FINAL RANKING:" section with unnumbered responses (first fallback).
- Missing "FINAL RANKING:" section (second fallback).
- Input with extra text and multiple mentions of "Response X" before the ranking section.
- Input with no "Response X" mentions.
- Multiple digits in numbering (e.g., "10. Response J").
- Case variations (e.g., "final ranking", "response A").
- Varied whitespace and separators.

### ✨ Result
The logic is now more robust against diverse LLM response formats. All tests in the project (81 total) pass, ensuring no regressions. Unrelated frontend lockfile changes were reverted.

---
*PR created automatically by Jules for task [16168449168870230566](https://jules.google.com/task/16168449168870230566) started by @ashwathravi*