### PR TITLE
feat(planner): streamline first-message workflow with starter prompts

### DIFF
--- a/Info/IMPROVEMENTS_ROADMAP.md
+++ b/Info/IMPROVEMENTS_ROADMAP.md
@@ -26,6 +26,12 @@ _Last updated: March 4, 2026_
 
 ## Follow-Up Queue
 
+
+- [ ] Guided “first prompt” onboarding
+  - Add one-tap starter prompts and keyboard shortcuts to reduce empty-state friction.
+
+- [ ] Session templates by intent
+  - Offer pre-baked council configurations (e.g., Debug, Product, Security) to speed setup.
 - [ ] Preset management enhancements
   - Add rename/delete/reorder support and optional “pin favorite preset”.
 

--- a/frontend/src/components/ChatInput.jsx
+++ b/frontend/src/components/ChatInput.jsx
@@ -8,7 +8,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { Badge } from "@/components/ui/badge";
 import { Paperclip, Send, X, FileText, Loader2 } from "lucide-react";
 
-const ChatInput = memo(({ conversationId, isLoading, onSendMessage }) => {
+const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPrompt = '' }) => {
   const [input, setInput] = useState('');
   const [documents, setDocuments] = useState([]);
   const [uploading, setUploading] = useState(false);
@@ -47,6 +47,23 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage }) => {
 
     loadDocuments();
   }, [conversationId]);
+
+  useEffect(() => {
+    if (!prefilledPrompt) return;
+    setInput(prefilledPrompt);
+    textareaRef.current?.focus();
+  }, [prefilledPrompt]);
+
+  useEffect(() => {
+    const focusComposer = (event) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'k') return;
+      event.preventDefault();
+      textareaRef.current?.focus();
+    };
+
+    window.addEventListener('keydown', focusComposer);
+    return () => window.removeEventListener('keydown', focusComposer);
+  }, []);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -220,7 +237,7 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage }) => {
             value={input}
             onChange={e => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Message the Council..."
+            placeholder="Message the Council... (Ctrl/Cmd+K to focus)"
             aria-label="Message input"
             spellCheck={false}
             className="min-h-[44px] w-full resize-none border-0 bg-transparent py-3 focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import MessageItem from './MessageItem';
 import ChatHeader from './ChatHeader';
 import ChatInput from './ChatInput';
@@ -12,6 +12,13 @@ export default function ChatInterface({
   isLoading,
 }) {
   const messagesEndRef = useRef(null);
+  const [prefilledPrompt, setPrefilledPrompt] = useState('');
+
+  const starterPrompts = [
+    'Give me a concise implementation plan for this feature, including risks and rollout steps.',
+    'Compare two technical approaches and recommend one with trade-offs.',
+    'Review this idea for accessibility and performance gaps before we ship.',
+  ];
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -49,6 +56,22 @@ export default function ChatInterface({
           <div className="h-full flex flex-col items-center justify-center text-center text-muted-foreground opacity-70">
             <h2 className="text-xl font-semibold mb-2">Start a conversation</h2>
             <p>Ask a question to consult the LLM Council</p>
+            <div className="mt-5 max-w-2xl">
+              <p className="text-xs uppercase tracking-wide mb-2">Starter prompts</p>
+              <div className="flex flex-wrap justify-center gap-2">
+                {starterPrompts.map((prompt) => (
+                  <button
+                    key={prompt}
+                    type="button"
+                    onClick={() => setPrefilledPrompt(prompt)}
+                    className="rounded-full border bg-background px-3 py-1.5 text-xs text-foreground hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    aria-label={`Use starter prompt: ${prompt}`}
+                  >
+                    {prompt}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
         ) : (
           conversation.messages.map((msg, index) => (
@@ -69,6 +92,7 @@ export default function ChatInterface({
         conversationId={conversation.id}
         isLoading={isLoading}
         onSendMessage={onSendMessage}
+        prefilledPrompt={prefilledPrompt}
       />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Reduce empty-state friction by giving users one-tap starter prompts so they can begin consulting the council without composing a prompt from scratch.  
- Speed up repeat usage by enabling a keyboard-first composer focus shortcut (`Ctrl/Cmd+K`) to minimize pointer travel.  
- Track product follow-ups for onboarding and session templates in the roadmap so the improvements remain visible to the team.

### Description
- Added a small list of starter prompts and an in-empty-state UI in `frontend/src/components/ChatInterface.jsx` that prefills the composer when a prompt is tapped.  
- Added a `prefilledPrompt` prop to `ChatInput` and implemented auto-fill + autofocus behavior in `frontend/src/components/ChatInput.jsx`.  
- Implemented a lightweight global key listener that focuses the composer on `Ctrl/Cmd+K` and updated the input placeholder to hint the shortcut.  
- Recorded follow-up items in `Info/IMPROVEMENTS_ROADMAP.md` for guided first-prompt onboarding and intent-based session templates.

### Testing
- Ran `npm run lint` in `frontend/` and it passed.  
- Ran `npm run build` in `frontend/` and the production build completed successfully.  
- Captured light/dark screenshots of the updated empty state (artifacts generated during local smoke testing).  
- No new automated unit/E2E tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9d3e4c7e48322804ea2ecb0143ef1)