### PR TITLE
feat(planner): add intent-based session templates

### DIFF
--- a/Info/IMPROVEMENTS_ROADMAP.md
+++ b/Info/IMPROVEMENTS_ROADMAP.md
@@ -30,8 +30,11 @@ _Last updated: March 4, 2026_
 - [ ] Guided “first prompt” onboarding
   - Add one-tap starter prompts and keyboard shortcuts to reduce empty-state friction.
 
-- [ ] Session templates by intent
-  - Offer pre-baked council configurations (e.g., Debug, Product, Security) to speed setup.
+- [x] Session templates by intent
+  - Status: Implemented.
+  - Frontend:
+    - Added intent templates (Debug, Product, Security) to the council configuration dialog.
+    - Applying a template pre-selects framework, suggested council members, and a chairman.
 - [ ] Preset management enhancements
   - Add rename/delete/reorder support and optional “pin favorite preset”.
 
@@ -43,4 +46,5 @@ _Last updated: March 4, 2026_
 
 ## Progress Log
 
+- 2026-03-05: Added intent-based session templates in the council configuration flow (Debug/Product/Security) with one-tap application.
 - 2026-03-04: Implemented retry endpoint + UI action, added comparison diff tab, and re-established roadmap tracking file.

--- a/frontend/src/components/CouncilConfigDialog.jsx
+++ b/frontend/src/components/CouncilConfigDialog.jsx
@@ -37,6 +37,30 @@ const COUNCIL_TYPES = [
   },
 ];
 
+const INTENT_TEMPLATES = [
+  {
+    id: 'debug',
+    name: 'Debug',
+    description: 'Biases toward strong coding and reasoning models for bug triage and fixes.',
+    framework: 'debate',
+    hints: ['gpt', 'claude', 'gemini', 'sonnet', 'o3'],
+  },
+  {
+    id: 'product',
+    name: 'Product',
+    description: 'Balanced council for prioritization, UX trade-offs, and go-to-market planning.',
+    framework: 'standard',
+    hints: ['gpt', 'claude', 'gemini', 'command', 'mixtral'],
+  },
+  {
+    id: 'security',
+    name: 'Security',
+    description: 'Focuses on threat modeling, risk analysis, and safer implementation paths.',
+    framework: 'six_hats',
+    hints: ['gpt', 'claude', 'gemini', 'o3', 'deepseek'],
+  },
+];
+
 const clampSelectionLimit = (value) => {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return 5;
@@ -72,6 +96,7 @@ const CouncilConfigDialog = ({
   setMaxCouncilModels,
 }) => {
   const [activePresetId, setActivePresetId] = useState(null);
+  const [activeTemplateId, setActiveTemplateId] = useState(null);
   const [memberView, setMemberView] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -109,6 +134,7 @@ const CouncilConfigDialog = ({
 
   const applySavedPreset = (preset) => {
     setActivePresetId(preset.id);
+    setActiveTemplateId(null);
 
     const nextFramework = preset.framework || 'standard';
     const requestedChairman = preset.chairmanModel || '';
@@ -125,8 +151,36 @@ const CouncilConfigDialog = ({
     setActiveView('new_config');
   };
 
+  const applyIntentTemplate = (template) => {
+    setActiveTemplateId(template.id);
+    setActivePresetId(null);
+
+    const availableModelIds = new Set(models.map((model) => model.id));
+    const scoredModels = models
+      .map((model) => {
+        const haystack = `${model.name} ${model.id}`.toLowerCase();
+        const score = template.hints.reduce((total, hint) => total + (haystack.includes(hint) ? 1 : 0), 0);
+        return { ...model, score };
+      })
+      .sort((a, b) => b.score - a.score);
+
+    const selectedModels = scoredModels
+      .filter((model) => model.score > 0)
+      .slice(0, maxCouncilModels)
+      .map((model) => model.id);
+
+    const fallbackModels = scoredModels.slice(0, maxCouncilModels).map((model) => model.id);
+    const nextCouncilModels = (selectedModels.length > 0 ? selectedModels : fallbackModels)
+      .filter((id) => availableModelIds.has(id));
+
+    setSelectedFramework(template.framework);
+    setCouncilModels(nextCouncilModels);
+    setChairmanModel(nextCouncilModels[0] || '');
+  };
+
   const toggleModel = (modelId) => {
     setActivePresetId(null);
+    setActiveTemplateId(null);
 
     if (councilModels.includes(modelId)) {
       const updatedModels = councilModels.filter((id) => id !== modelId);
@@ -153,6 +207,7 @@ const CouncilConfigDialog = ({
   const handleMaxSelectionChange = (value) => {
     setMaxCouncilModels(clampSelectionLimit(value));
     setActivePresetId(null);
+    setActiveTemplateId(null);
   };
 
   const renderModelRows = (modelList, allowFavoriteToggle) => {
@@ -293,6 +348,46 @@ const CouncilConfigDialog = ({
 
       <div className="flex-1 overflow-y-auto px-6 py-2">
         <TabsContent value="new_config" className="mt-0 space-y-6 pb-6">
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-muted-foreground">Session Templates</h3>
+              <div className="text-xs text-muted-foreground">Intent presets</div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              {INTENT_TEMPLATES.map((template) => (
+                <Card
+                  key={template.id}
+                  role="button"
+                  tabIndex={0}
+                  aria-pressed={activeTemplateId === template.id}
+                  className={cn(
+                    'cursor-pointer hover:bg-accent/50 transition-colors relative focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none',
+                    activeTemplateId === template.id ? 'border-primary bg-accent/20' : ''
+                  )}
+                  onClick={() => applyIntentTemplate(template)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      applyIntentTemplate(template);
+                    }
+                  }}
+                >
+                  <CardContent className="p-4 space-y-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="font-semibold text-primary">{template.name}</div>
+                      {activeTemplateId === template.id && <Check className="h-4 w-4 text-primary" />}
+                    </div>
+                    <p className="text-xs text-foreground/90">{template.description}</p>
+                    <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                      {getFrameworkLabel(template.framework)}
+                    </Badge>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+
           <div className="space-y-3">
             <h3 className="text-sm font-semibold text-muted-foreground">Council Types</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">


### PR DESCRIPTION
### Motivation
- Provide one-tap, intent-focused starting points (Debug/Product/Security) to reduce setup friction and speed session creation.
- Auto-select a recommended framework, suggested council members, and a chairman to lower cognitive load for users configuring a session.
- Keep roadmap tracking accurate by marking the session-templates-by-intent item as implemented.

### Description
- Added `INTENT_TEMPLATES` and a `Session Templates` UI section in `frontend/src/components/CouncilConfigDialog.jsx` that surfaces Debug, Product, and Security templates as clickable cards.
- Implemented `applyIntentTemplate` which scores available models by name/id hints and pre-selects `selectedFramework`, `councilModels`, and `chairmanModel`, and it clears conflicting preset/template state when users switch selections.
- Template cards are keyboard accessible with `tabIndex=0`, support `Enter`/`Space` activation, and expose active state with `aria-pressed`, while preserving existing labels and controls.
- Updated `Info/IMPROVEMENTS_ROADMAP.md` to mark session templates as implemented and added a progress log entry.

### Testing
- Ran `npm --prefix frontend run lint` which completed successfully.
- Ran `npm --prefix frontend run build` which produced a successful production bundle.
- Launched the dev server and captured light and dark screenshots at `artifacts/session-template-light.png` and `artifacts/session-template-dark.png` to validate the UI.
- No automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9d8e227bc83229c6f4ddbbee7fb44)