### PR TITLE
feat(planner): guided first-prompt onboarding with keyboard shortcuts

### DIFF
--- a/Info/IMPROVEMENTS_ROADMAP.md
+++ b/Info/IMPROVEMENTS_ROADMAP.md
@@ -27,8 +27,11 @@ _Last updated: March 4, 2026_
 ## Follow-Up Queue
 
 
-- [ ] Guided “first prompt” onboarding
-  - Add one-tap starter prompts and keyboard shortcuts to reduce empty-state friction.
+- [x] Guided “first prompt” onboarding
+  - Status: Implemented.
+  - Frontend:
+    - Added starter prompt quick picks in the empty conversation state.
+    - Added keyboard shortcuts (`Alt+1/2/3`) to prefill starter prompts and surfaced shortcut hints in the UI.
 
 - [x] Session templates by intent
   - Status: Implemented.
@@ -46,5 +49,6 @@ _Last updated: March 4, 2026_
 
 ## Progress Log
 
+- 2026-03-05: Added guided “first prompt” onboarding with starter prompt quick picks, Alt+1/2/3 shortcuts, and send shortcut guidance in empty-state UI.
 - 2026-03-05: Added intent-based session templates in the council configuration flow (Debug/Product/Security) with one-tap application.
 - 2026-03-04: Implemented retry endpoint + UI action, added comparison diff tab, and re-established roadmap tracking file.

--- a/frontend/src/components/ChatInput.jsx
+++ b/frontend/src/components/ChatInput.jsx
@@ -76,7 +76,10 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPro
   };
 
   const handleKeyDown = (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    const isPrimaryModifierEnter = (e.ctrlKey || e.metaKey) && e.key === 'Enter';
+    const isStandardSend = e.key === 'Enter' && !e.shiftKey;
+
+    if (isStandardSend || isPrimaryModifierEnter) {
       e.preventDefault();
       handleSubmit(e);
     }

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -5,6 +5,12 @@ import ChatHeader from './ChatHeader';
 import ChatInput from './ChatInput';
 import { BrainCircuit } from "lucide-react";
 
+const STARTER_PROMPTS = [
+  'Give me a concise implementation plan for this feature, including risks and rollout steps.',
+  'Compare two technical approaches and recommend one with trade-offs.',
+  'Review this idea for accessibility and performance gaps before we ship.',
+];
+
 export default function ChatInterface({
   conversation,
   onSendMessage,
@@ -14,11 +20,22 @@ export default function ChatInterface({
   const messagesEndRef = useRef(null);
   const [prefilledPrompt, setPrefilledPrompt] = useState('');
 
-  const starterPrompts = [
-    'Give me a concise implementation plan for this feature, including risks and rollout steps.',
-    'Compare two technical approaches and recommend one with trade-offs.',
-    'Review this idea for accessibility and performance gaps before we ship.',
-  ];
+  useEffect(() => {
+    if (!conversation || conversation.messages.length > 0) return undefined;
+
+    const onStarterPromptShortcut = (event) => {
+      if (!event.altKey) return;
+
+      const index = Number(event.key) - 1;
+      if (Number.isNaN(index) || index < 0 || index >= STARTER_PROMPTS.length) return;
+
+      event.preventDefault();
+      setPrefilledPrompt(STARTER_PROMPTS[index]);
+    };
+
+    window.addEventListener('keydown', onStarterPromptShortcut);
+    return () => window.removeEventListener('keydown', onStarterPromptShortcut);
+  }, [conversation]);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -56,18 +73,21 @@ export default function ChatInterface({
           <div className="h-full flex flex-col items-center justify-center text-center text-muted-foreground opacity-70">
             <h2 className="text-xl font-semibold mb-2">Start a conversation</h2>
             <p>Ask a question to consult the LLM Council</p>
+            <div className="mt-3 rounded-md border border-dashed px-3 py-2 text-xs">
+              <p>Shortcuts: <span className="font-medium">Alt+1/2/3</span> for starter prompts · <span className="font-medium">Ctrl/Cmd+Enter</span> to send</p>
+            </div>
             <div className="mt-5 max-w-2xl">
               <p className="text-xs uppercase tracking-wide mb-2">Starter prompts</p>
               <div className="flex flex-wrap justify-center gap-2">
-                {starterPrompts.map((prompt) => (
+                {STARTER_PROMPTS.map((prompt, index) => (
                   <button
                     key={prompt}
                     type="button"
                     onClick={() => setPrefilledPrompt(prompt)}
                     className="rounded-full border bg-background px-3 py-1.5 text-xs text-foreground hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    aria-label={`Use starter prompt: ${prompt}`}
+                    aria-label={`Use starter prompt ${index + 1}: ${prompt}`}
                   >
-                    {prompt}
+                    {index + 1}. {prompt}
                   </button>
                 ))}
               </div>


### PR DESCRIPTION
### Motivation

- Complete the roadmap item to reduce empty-state friction by providing guided starter prompts and discoverable keyboard shortcuts.
- Improve keyboard-first workflows so users can quickly prefill a starter prompt and send messages without leaving the keyboard.

### Description

- Add a `STARTER_PROMPTS` constant and surface numbered starter prompt chips in the empty conversation UI (`frontend/src/components/ChatInterface.jsx`).
- Add an `Alt+1/2/3` keydown listener that prefills the corresponding starter prompt only when the conversation has no messages (`frontend/src/components/ChatInterface.jsx`).
- Surface shortcut guidance and update starter prompt button labels to include numeric indices for clarity and accessibility (`frontend/src/components/ChatInterface.jsx`).
- Expand composer behavior so `Ctrl/Cmd+Enter` also submits the composer in addition to the existing Enter behavior (`frontend/src/components/ChatInput.jsx`).
- Mark the onboarding task complete and log the change in `Info/IMPROVEMENTS_ROADMAP.md`.

### Testing

- Ran `npm run lint` in `frontend/` and it passed with no lint errors.
- Ran `npm run build` in `frontend/` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9db6857a88322b893b6bcf8c4a6c8)