### PR TITLE
feat(planner): add preset management controls to council config

### DIFF
--- a/Info/IMPROVEMENTS_ROADMAP.md
+++ b/Info/IMPROVEMENTS_ROADMAP.md
@@ -38,8 +38,11 @@ _Last updated: March 4, 2026_
   - Frontend:
     - Added intent templates (Debug, Product, Security) to the council configuration dialog.
     - Applying a template pre-selects framework, suggested council members, and a chairman.
-- [ ] Preset management enhancements
-  - Add rename/delete/reorder support and optional “pin favorite preset”.
+- [x] Preset management enhancements
+  - Status: Implemented.
+  - Frontend:
+    - Added preset actions in configuration dialog for rename, delete, and manual reorder.
+    - Added optional pin/unpin toggle with pinned presets surfaced first in the saved preset list.
 
 - [ ] Retry granularity improvements
   - Add per-model retry buttons and explicit retry result toasts.
@@ -51,4 +54,5 @@ _Last updated: March 4, 2026_
 
 - 2026-03-05: Added guided “first prompt” onboarding with starter prompt quick picks, Alt+1/2/3 shortcuts, and send shortcut guidance in empty-state UI.
 - 2026-03-05: Added intent-based session templates in the council configuration flow (Debug/Product/Security) with one-tap application.
+- 2026-03-05: Added preset management controls (rename/delete/reorder/pin) to saved configurations in council setup.
 - 2026-03-04: Implemented retry endpoint + UI action, added comparison diff tab, and re-established roadmap tracking file.

--- a/frontend/src/components/CouncilConfigDialog.jsx
+++ b/frontend/src/components/CouncilConfigDialog.jsx
@@ -6,7 +6,7 @@ import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Check, Crown, Save, Settings2, Star, Users, Search } from "lucide-react";
+import { Check, Crown, Save, Settings2, Star, Users, Search, Pin, Pencil, Trash2, ArrowUp, ArrowDown } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
@@ -88,6 +88,10 @@ const CouncilConfigDialog = ({
   setChairmanModel,
   presets,
   onSavePreset,
+  onRenamePreset,
+  onDeletePreset,
+  onTogglePresetPin,
+  onMovePreset,
   activeView,
   setActiveView,
   favoriteModels,
@@ -131,6 +135,12 @@ const CouncilConfigDialog = ({
   );
 
   const getModelName = (modelId) => models.find((model) => model.id === modelId)?.name || modelId;
+
+  const sortedPresets = useMemo(() => {
+    const pinned = presets.filter((preset) => preset.pinned);
+    const unpinned = presets.filter((preset) => !preset.pinned);
+    return [...pinned, ...unpinned];
+  }, [presets]);
 
   const applySavedPreset = (preset) => {
     setActivePresetId(preset.id);
@@ -494,7 +504,7 @@ const CouncilConfigDialog = ({
               </div>
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                {presets.map((preset) => (
+                {sortedPresets.map((preset, index) => (
                   <Card
                     key={preset.id}
                     role="button"
@@ -514,8 +524,90 @@ const CouncilConfigDialog = ({
                   >
                     <CardContent className="p-4">
                       <div className="flex justify-between items-start mb-2">
-                        <div className="font-semibold text-sm">{preset.name}</div>
-                        {activePresetId === preset.id && <Check className="h-4 w-4 text-primary" />}
+                        <div className="font-semibold text-sm flex items-center gap-2">
+                          <span>{preset.name}</span>
+                          {preset.pinned && (
+                            <Badge variant="secondary" className="h-5 px-1.5 gap-1 text-[10px]">
+                              <Pin className="h-3 w-3" />
+                              Pinned
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-1">
+                          {activePresetId === preset.id && <Check className="h-4 w-4 text-primary" />}
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            aria-label={`Move ${preset.name} up`}
+                            title="Move up"
+                            disabled={index === 0}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onMovePreset(preset.id, 'up');
+                            }}
+                          >
+                            <ArrowUp className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            aria-label={`Move ${preset.name} down`}
+                            title="Move down"
+                            disabled={index === sortedPresets.length - 1}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onMovePreset(preset.id, 'down');
+                            }}
+                          >
+                            <ArrowDown className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            aria-label={preset.pinned ? `Unpin ${preset.name}` : `Pin ${preset.name}`}
+                            title={preset.pinned ? 'Unpin preset' : 'Pin preset'}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onTogglePresetPin(preset.id);
+                            }}
+                          >
+                            <Pin className={cn('h-3.5 w-3.5', preset.pinned ? 'text-primary fill-primary/20' : '')} />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            aria-label={`Rename ${preset.name}`}
+                            title="Rename preset"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onRenamePreset(preset.id);
+                            }}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-destructive hover:text-destructive"
+                            aria-label={`Delete ${preset.name}`}
+                            title="Delete preset"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onDeletePreset(preset.id);
+                            }}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
                       </div>
                       <p className="text-xs text-muted-foreground">{preset.description}</p>
                     </CardContent>

--- a/frontend/src/components/CouncilSidebar.jsx
+++ b/frontend/src/components/CouncilSidebar.jsx
@@ -33,6 +33,11 @@ const readSavedPresets = () => {
   }
 };
 
+const persistPresets = (nextPresets, setPresets) => {
+  setPresets(nextPresets);
+  localStorage.setItem('council_presets', JSON.stringify(nextPresets));
+};
+
 const readFavoriteModels = () => {
   const savedFavorites = localStorage.getItem('favorite_models');
   if (!savedFavorites) return [];
@@ -222,11 +227,65 @@ const CouncilSidebar = memo(({
       framework: selectedFramework,
       chairmanModel,
       councilModels,
+      pinned: false,
     };
 
-    const updatedPresets = [...presets, newPreset];
-    setPresets(updatedPresets);
-    localStorage.setItem('council_presets', JSON.stringify(updatedPresets));
+    persistPresets([...presets, newPreset], setPresets);
+  };
+
+  const handleRenamePreset = (presetId) => {
+    const targetPreset = presets.find((preset) => preset.id === presetId);
+    if (!targetPreset) return;
+
+    const nextName = prompt('Rename preset:', targetPreset.name);
+    if (nextName === null) return;
+
+    const trimmedName = nextName.trim();
+    if (!trimmedName) {
+      alert('Preset name cannot be empty.');
+      return;
+    }
+
+    persistPresets(
+      presets.map((preset) =>
+        preset.id === presetId
+          ? { ...preset, name: trimmedName }
+          : preset
+      ),
+      setPresets
+    );
+  };
+
+  const handleDeletePreset = (presetId) => {
+    const targetPreset = presets.find((preset) => preset.id === presetId);
+    if (!targetPreset) return;
+    if (!confirm(`Delete preset "${targetPreset.name}"?`)) return;
+
+    persistPresets(presets.filter((preset) => preset.id !== presetId), setPresets);
+  };
+
+  const handleTogglePresetPin = (presetId) => {
+    persistPresets(
+      presets.map((preset) =>
+        preset.id === presetId
+          ? { ...preset, pinned: !preset.pinned }
+          : preset
+      ),
+      setPresets
+    );
+  };
+
+  const handleMovePreset = (presetId, direction) => {
+    const currentIndex = presets.findIndex((preset) => preset.id === presetId);
+    if (currentIndex === -1) return;
+
+    const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+    if (targetIndex < 0 || targetIndex >= presets.length) return;
+
+    const reorderedPresets = [...presets];
+    const [movedPreset] = reorderedPresets.splice(currentIndex, 1);
+    reorderedPresets.splice(targetIndex, 0, movedPreset);
+    persistPresets(reorderedPresets, setPresets);
   };
 
   const handleMaxCouncilModelsChange = (nextMaxValue) => {
@@ -513,6 +572,10 @@ const CouncilSidebar = memo(({
         setChairmanModel={setChairmanModel}
         presets={presets}
         onSavePreset={saveNewPreset}
+        onRenamePreset={handleRenamePreset}
+        onDeletePreset={handleDeletePreset}
+        onTogglePresetPin={handleTogglePresetPin}
+        onMovePreset={handleMovePreset}
         activeView={configDialogView}
         setActiveView={setConfigDialogView}
         favoriteModels={favoriteModels}


### PR DESCRIPTION
### Motivation
- Implement the next roadmap item to let users manage saved council presets without leaving the configuration dialog (rename, delete, reorder, pin).
- Improve UX by surfacing pinned presets first and adding accessible, keyboard-friendly management controls inline with saved presets.

### Description
- Added persistent helpers and state updates in `frontend/src/components/CouncilSidebar.jsx` including `persistPresets`, a `pinned` field on new presets, and handlers `handleRenamePreset`, `handleDeletePreset`, `handleTogglePresetPin`, and `handleMovePreset` to manage presets in localStorage.
- Wired new handlers into `CouncilConfigDialog` props and implemented pinned-first sorting with `useMemo` plus per-preset action buttons (move up/down, pin/unpin, rename, delete) in `frontend/src/components/CouncilConfigDialog.jsx` with `aria-label`/`title` attributes and `event.stopPropagation()` to avoid accidental applies.
- Updated `Info/IMPROVEMENTS_ROADMAP.md` to mark the preset management enhancements as implemented and logged the progress entry.

### Testing
- Ran frontend lint with `cd frontend && npm run lint` and it passed.
- Built the frontend with `cd frontend && npm run build` and the Vite production build succeeded (non-blocking chunk-size warning reported). 
- Automated UI verification: captured light/dark screenshots via a Playwright script; artifacts saved as `artifacts/preset-management-light.png` and `artifacts/preset-management-dark.png`.
- No new unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9dcb8de8883228c8d57c46b913f5a)