### PR TITLE
feat(planner): add per-model retry actions and retry outcome toasts

### DIFF
--- a/Info/IMPROVEMENTS_ROADMAP.md
+++ b/Info/IMPROVEMENTS_ROADMAP.md
@@ -44,14 +44,18 @@ _Last updated: March 4, 2026_
     - Added preset actions in configuration dialog for rename, delete, and manual reorder.
     - Added optional pin/unpin toggle with pinned presets surfaced first in the saved preset list.
 
-- [ ] Retry granularity improvements
-  - Add per-model retry buttons and explicit retry result toasts.
+- [x] Retry granularity improvements
+  - Status: Implemented.
+  - Frontend:
+    - Added per-model retry buttons inside the council error panel.
+    - Added explicit success/error retry toasts with recovered vs still-failing counts.
 
 - [ ] Synthesis refresh option after retry
   - Optional action to rerun Stage 2 + Stage 3 using recovered Stage 1 responses.
 
 ## Progress Log
 
+- 2026-03-05: Added granular Stage 1 retry UX with per-model retry actions and explicit retry outcome toasts.
 - 2026-03-05: Added guided “first prompt” onboarding with starter prompt quick picks, Alt+1/2/3 shortcuts, and send shortcut guidance in empty-state UI.
 - 2026-03-05: Added intent-based session templates in the council configuration flow (Debug/Product/Security) with one-tap application.
 - 2026-03-05: Added preset management controls (rename/delete/reorder/pin) to saved configurations in council setup.

--- a/frontend/src/components/CouncilMessageBlock.jsx
+++ b/frontend/src/components/CouncilMessageBlock.jsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
 import { AlertTriangle, Trophy, Crown, BrainCircuit, GitCompareArrows, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -256,6 +257,8 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
   const { stage1, stage2, stage3, loading, errors, metadata } = message;
   const [activeTab, setActiveTab] = useState('consensus');
   const [isRetryingFailedModels, setIsRetryingFailedModels] = useState(false);
+  const [retryingModels, setRetryingModels] = useState([]);
+  const { toast } = useToast();
 
   const hasStage1 = stage1 && stage1.length > 0;
   const hasStage2 = stage2 && stage2.length > 0;
@@ -326,17 +329,61 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
     failedModelIds.length > 0
   );
 
-  const handleRetryFailedModels = async () => {
-    if (!canRetryFailedModels || isRetryingFailedModels) return;
-    setIsRetryingFailedModels(true);
+  const handleRetryModels = async (modelsToRetry) => {
+    if (!canRetryFailedModels || !Array.isArray(modelsToRetry) || modelsToRetry.length === 0) return;
+    const uniqueModels = [...new Set(modelsToRetry.filter(Boolean))];
+    const isBulkRetry = uniqueModels.length > 1;
+
+    if (isBulkRetry) {
+      if (isRetryingFailedModels) return;
+      setIsRetryingFailedModels(true);
+    } else {
+      if (retryingModels.includes(uniqueModels[0])) return;
+      setRetryingModels((prev) => [...prev, uniqueModels[0]]);
+    }
+
     try {
-      await onRetryFailedModels(messageIndex, failedModelIds);
+      const retryResult = await onRetryFailedModels(messageIndex, uniqueModels);
+      const recoveredModels = Array.isArray(retryResult?.recovered_models)
+        ? retryResult.recovered_models
+        : [];
+      const failedModels = Array.isArray(retryResult?.failed_models)
+        ? retryResult.failed_models
+        : [];
+
+      const title = failedModels.length > 0 ? 'Retry completed with some failures' : 'Retry completed';
+      const description = [
+        `Recovered: ${recoveredModels.length}`,
+        `Still failing: ${failedModels.length}`,
+      ].join(' • ');
+
+      toast({
+        title,
+        description,
+        variant: failedModels.length > 0 ? 'destructive' : 'default',
+      });
     } catch (error) {
       const detail = error instanceof Error ? error.message : 'Failed to retry models';
-      alert(detail);
+      toast({
+        title: 'Retry failed',
+        description: detail,
+        variant: 'destructive',
+      });
     } finally {
-      setIsRetryingFailedModels(false);
+      if (isBulkRetry) {
+        setIsRetryingFailedModels(false);
+      } else {
+        setRetryingModels((prev) => prev.filter((modelName) => modelName !== uniqueModels[0]));
+      }
     }
+  };
+
+  const handleRetryFailedModels = async () => {
+    await handleRetryModels(failedModelIds);
+  };
+
+  const handleRetrySingleModel = async (modelName) => {
+    await handleRetryModels([modelName]);
   };
 
   return (
@@ -459,9 +506,25 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
                 </Button>
               )}
             </div>
-            <ul className="list-disc list-inside">
+            <ul className="space-y-2">
               {combinedErrors.map((err, idx) => (
-                <li key={idx}><strong>{err.model}:</strong> {err.error}</li>
+                <li key={idx} className="flex flex-col gap-2 rounded border border-destructive/20 bg-background/50 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <strong>{err.model}:</strong> {err.error}
+                  </div>
+                  {canRetryFailedModels && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 border-destructive/40 text-destructive hover:text-destructive"
+                      onClick={() => handleRetrySingleModel(extractRetryModelName(err.model))}
+                      disabled={isRetryingFailedModels || retryingModels.includes(extractRetryModelName(err.model))}
+                    >
+                      <RotateCcw className={cn('mr-1 h-3.5 w-3.5', retryingModels.includes(extractRetryModelName(err.model)) && 'animate-spin')} />
+                      {retryingModels.includes(extractRetryModelName(err.model)) ? 'Retrying...' : 'Retry model'}
+                    </Button>
+                  )}
+                </li>
               ))}
             </ul>
           </div>


### PR DESCRIPTION
### Motivation
- Improve retry UX by allowing users to re-run only specific failed Stage 1 models instead of always retrying all failures. 
- Provide non-blocking feedback for retry outcomes so users can see how many models recovered vs remain failing. 
- Keep existing bulk retry flow while adding per-model granularity and explicit telemetry in the roadmap.

### Description
- Frontend: updated `frontend/src/components/CouncilMessageBlock.jsx` to add per-model retry buttons, per-model in-flight state (`retryingModels`), and consolidated retry logic via `handleRetryModels`, `handleRetrySingleModel`, and `handleRetryFailedModels`.
- Frontend: integrated the app toast system (`useToast`) to surface concise retry outcome notifications showing `Recovered` and `Still failing` counts and mark toasts as destructive when failures remain.
- Frontend: adjusted error list markup to include per-error retry controls and non-blocking bulk retry behavior that preserves the existing `Retry Failed Models` button.
- Docs: updated `Info/IMPROVEMENTS_ROADMAP.md` to mark `Retry granularity improvements` as implemented and added a progress-log entry for this work.

### Testing
- Ran frontend lint with `cd frontend && npm run lint`, which completed successfully.
- Built the frontend with `cd frontend && npm run build`, which completed successfully.
- Launched the dev server and captured light/dark screenshots via an automated Playwright script, which ran and produced screenshots for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9de155c308322a372980a3f94319f)