### PR TITLE
feat(planner): add synthesis refresh action after stage1 retries

### DIFF
--- a/Info/IMPROVEMENTS_ROADMAP.md
+++ b/Info/IMPROVEMENTS_ROADMAP.md
@@ -50,11 +50,18 @@ _Last updated: March 4, 2026_
     - Added per-model retry buttons inside the council error panel.
     - Added explicit success/error retry toasts with recovered vs still-failing counts.
 
-- [ ] Synthesis refresh option after retry
-  - Optional action to rerun Stage 2 + Stage 3 using recovered Stage 1 responses.
+- [x] Synthesis refresh option after retry
+  - Status: Implemented.
+  - Backend:
+    - Added `POST /api/conversations/{conversation_id}/messages/{message_index}/refresh-synthesis`.
+    - Recomputes Stage 2 + Stage 3 using the message's latest Stage 1 responses while preserving conversation context and retrieval citations.
+  - Frontend:
+    - Added per-message `Refresh synthesis` action once Stage 1 retries exist.
+    - Updates rankings, consensus output, and metadata in place after refresh.
 
 ## Progress Log
 
+- 2026-03-05: Added post-retry synthesis refresh endpoint + UI action to recompute Stage 2/3 from recovered Stage 1 responses.
 - 2026-03-05: Added granular Stage 1 retry UX with per-model retry actions and explicit retry outcome toasts.
 - 2026-03-05: Added guided “first prompt” onboarding with starter prompt quick picks, Alt+1/2/3 shortcuts, and send shortcut guidance in empty-state UI.
 - 2026-03-05: Added intent-based session templates in the council configuration flow (Debug/Product/Security) with one-tap application.

--- a/backend/main.py
+++ b/backend/main.py
@@ -117,6 +117,11 @@ class RetryStage1Request(BaseModel):
         return v
 
 
+class RefreshSynthesisRequest(BaseModel):
+    """Request to refresh Stage 2 + Stage 3 for an existing assistant message."""
+    force: bool = False
+
+
 class ConversationMetadata(BaseModel):
     """Conversation metadata for list view."""
     id: str
@@ -709,6 +714,141 @@ async def retry_failed_stage1_models(
         "retried_models": retry_models,
         "recovered_models": [item["model"] for item in retry_stage1_results],
         "failed_models": [item["model"] for item in retry_stage1_errors],
+        "metadata": metadata,
+    }
+
+
+@app.post(
+    "/api/conversations/{conversation_id}/messages/{message_index}/refresh-synthesis",
+    dependencies=[Depends(security.rate_limiter(requests_limit=20, time_window=60, scope="chat"))]
+)
+async def refresh_synthesis_for_message(
+    conversation_id: str,
+    message_index: int,
+    request: RefreshSynthesisRequest,
+    user_id: str = Depends(auth.get_current_user_id)
+):
+    """Recompute Stage 2 + Stage 3 for an assistant message using current Stage 1 results."""
+    conversation = await storage.get_conversation(conversation_id, user_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    messages = conversation.get("messages", [])
+    if message_index < 0 or message_index >= len(messages):
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    target_message = messages[message_index]
+    if target_message.get("role") != "assistant":
+        raise HTTPException(status_code=400, detail="Synthesis refresh is only supported for assistant messages")
+
+    existing_stage1 = target_message.get("stage1")
+    if not isinstance(existing_stage1, list) or len(existing_stage1) == 0:
+        raise HTTPException(status_code=400, detail="Cannot refresh synthesis without Stage 1 responses")
+
+    previous_user_index = _find_previous_user_message_index(messages, message_index)
+    if previous_user_index is None:
+        raise HTTPException(status_code=400, detail="No matching user message found for synthesis refresh")
+
+    history = _build_history_through_user_message(messages, previous_user_index)
+    user_query = history[-1]["content"] if history else ""
+    if not user_query.strip():
+        raise HTTPException(status_code=400, detail="Cannot refresh synthesis for an empty prompt")
+
+    existing_metadata = target_message.get("metadata")
+    metadata: Dict[str, Any] = dict(existing_metadata) if isinstance(existing_metadata, dict) else {}
+
+    framework = metadata.get("framework") or conversation.get("framework", "standard")
+    requested_council_models = metadata.get("requested_council_models")
+    if not isinstance(requested_council_models, list):
+        requested_council_models = list(conversation.get("council_models") or [])
+    effective_council_models = metadata.get("effective_council_models")
+    if not isinstance(effective_council_models, list) or not effective_council_models:
+        effective_council_models = resolve_active_models(requested_council_models)
+
+    chairman_model = metadata.get("chairman_model") or conversation.get("chairman_model") or config.CHAIRMAN_MODEL
+
+    retrieval_context, citations = await retrieval.build_retrieval_context(
+        conversation_id,
+        user_id,
+        user_query,
+    )
+
+    stage1_results = [
+        item for item in existing_stage1
+        if isinstance(item, dict) and isinstance(item.get("model"), str) and isinstance(item.get("response"), str)
+    ]
+
+    if not stage1_results:
+        raise HTTPException(status_code=400, detail="Cannot refresh synthesis without valid Stage 1 responses")
+
+    if framework == "debate":
+        refreshed_stage2, label_to_model = await stage2_collect_critiques(
+            user_query,
+            stage1_results,
+            effective_council_models,
+            retrieval_context=retrieval_context,
+        )
+        aggregate_rankings = []
+    elif framework == "ensemble":
+        refreshed_stage2 = []
+        labels = [chr(65 + i) for i in range(len(stage1_results))]
+        label_to_model = {
+            f"Response {label}": result["model"]
+            for label, result in zip(labels, stage1_results)
+        }
+        aggregate_rankings = []
+    else:
+        refreshed_stage2, label_to_model = await stage2_collect_rankings(
+            user_query,
+            stage1_results,
+            effective_council_models,
+            chairman_model,
+            retrieval_context=retrieval_context,
+        )
+        aggregate_rankings = calculate_aggregate_rankings(refreshed_stage2, label_to_model) if refreshed_stage2 else []
+
+    stage3_text = ""
+    async for chunk in stage3_synthesize_final(
+        user_query,
+        stage1_results,
+        refreshed_stage2,
+        chairman_model,
+        mode=framework,
+        retrieval_context=retrieval_context,
+    ):
+        stage3_text += chunk
+
+    refreshed_stage3 = {
+        "model": chairman_model,
+        "response": stage3_text,
+    }
+
+    refresh_history = metadata.get("synthesis_refresh_history")
+    refresh_history = list(refresh_history) if isinstance(refresh_history, list) else []
+    refresh_history.append({
+        "timestamp_ms": int(time.time() * 1000),
+        "stage1_count": len(stage1_results),
+        "force": request.force,
+    })
+
+    metadata["framework"] = framework
+    metadata["requested_council_models"] = requested_council_models
+    metadata["effective_council_models"] = effective_council_models
+    metadata["responded_council_models"] = [item["model"] for item in stage1_results]
+    metadata["chairman_model"] = chairman_model
+    metadata["label_to_model"] = label_to_model
+    metadata["aggregate_rankings"] = aggregate_rankings
+    metadata["retrieval"] = {"citations": citations}
+    metadata["synthesis_refresh_history"] = refresh_history
+
+    target_message["stage2"] = refreshed_stage2
+    target_message["stage3"] = refreshed_stage3
+    target_message["metadata"] = metadata
+    await storage.update_message(conversation_id, user_id, message_index, target_message)
+
+    return {
+        "stage2": refreshed_stage2,
+        "stage3": refreshed_stage3,
         "metadata": metadata,
     }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -407,6 +407,37 @@ function App() {
     return retryData;
   }, [currentConversationId]);
 
+  const handleRefreshSynthesis = useCallback(async (messageIndex) => {
+    if (!currentConversationId) return null;
+
+    const refreshData = await api.refreshSynthesis(currentConversationId, messageIndex);
+    setCurrentConversation((prev) => {
+      if (!prev || !Array.isArray(prev.messages)) return prev;
+      if (messageIndex < 0 || messageIndex >= prev.messages.length) return prev;
+
+      const messages = [...prev.messages];
+      const targetMessage = { ...messages[messageIndex] };
+      const existingMetadata = targetMessage.metadata || {};
+      const incomingMetadata = refreshData?.metadata || {};
+
+      targetMessage.stage2 = Array.isArray(refreshData?.stage2)
+        ? refreshData.stage2
+        : targetMessage.stage2;
+      targetMessage.stage3 = refreshData?.stage3 && typeof refreshData.stage3 === 'object'
+        ? refreshData.stage3
+        : targetMessage.stage3;
+      targetMessage.metadata = {
+        ...existingMetadata,
+        ...incomingMetadata,
+      };
+
+      messages[messageIndex] = targetMessage;
+      return { ...prev, messages };
+    });
+
+    return refreshData;
+  }, [currentConversationId]);
+
   if (authLoading) return <div className="flex h-screen items-center justify-center">Loading...</div>;
   if (!user) {
     return (
@@ -462,6 +493,7 @@ function App() {
             conversation={currentConversation}
             onSendMessage={handleSendMessage}
             onRetryFailedModels={handleRetryFailedModels}
+            onRefreshSynthesis={handleRefreshSynthesis}
             isLoading={isLoading}
           />
         </main>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -184,6 +184,34 @@ export const api = {
   },
 
   /**
+   * Recompute Stage 2 + Stage 3 synthesis for an assistant message.
+   */
+  async refreshSynthesis(conversationId, messageIndex) {
+    const response = await fetch(
+      `${API_BASE}/api/conversations/${conversationId}/messages/${messageIndex}/refresh-synthesis`,
+      {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({ force: false }),
+      }
+    );
+
+    if (!response.ok) {
+      let detail = 'Failed to refresh synthesis';
+      try {
+        const data = await response.json();
+        detail = data.detail || data.error || detail;
+      } catch {
+        const text = await response.text();
+        if (text) detail = text;
+      }
+      throw new Error(detail);
+    }
+
+    return response.json();
+  },
+
+  /**
    * Send a message and receive streaming updates.
    */
   async sendMessageStream(conversationId, content, onEvent) {

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -15,6 +15,7 @@ export default function ChatInterface({
   conversation,
   onSendMessage,
   onRetryFailedModels,
+  onRefreshSynthesis,
   isLoading,
 }) {
   const messagesEndRef = useRef(null);
@@ -100,6 +101,7 @@ export default function ChatInterface({
               msg={msg}
               messageIndex={index}
               onRetryFailedModels={onRetryFailedModels}
+              onRefreshSynthesis={onRefreshSynthesis}
             />
           ))
         )}

--- a/frontend/src/components/CouncilMessageBlock.jsx
+++ b/frontend/src/components/CouncilMessageBlock.jsx
@@ -253,10 +253,11 @@ const buildComparisonDiff = (stage1Results) => {
   return { consensusSentences, overlaps, uniqueTerms };
 };
 
-const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => {
+const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels, onRefreshSynthesis }) => {
   const { stage1, stage2, stage3, loading, errors, metadata } = message;
   const [activeTab, setActiveTab] = useState('consensus');
   const [isRetryingFailedModels, setIsRetryingFailedModels] = useState(false);
+  const [isRefreshingSynthesis, setIsRefreshingSynthesis] = useState(false);
   const [retryingModels, setRetryingModels] = useState([]);
   const { toast } = useToast();
 
@@ -329,6 +330,15 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
     failedModelIds.length > 0
   );
 
+  const canRefreshSynthesis = (
+    typeof onRefreshSynthesis === 'function' &&
+    Number.isInteger(messageIndex) &&
+    hasStage1 &&
+    hasStage3 &&
+    Array.isArray(metadata?.stage1_retry_history) &&
+    metadata.stage1_retry_history.length > 0
+  );
+
   const handleRetryModels = async (modelsToRetry) => {
     if (!canRetryFailedModels || !Array.isArray(modelsToRetry) || modelsToRetry.length === 0) return;
     const uniqueModels = [...new Set(modelsToRetry.filter(Boolean))];
@@ -386,6 +396,28 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
     await handleRetryModels([modelName]);
   };
 
+  const handleRefreshSynthesis = async () => {
+    if (!canRefreshSynthesis || isRefreshingSynthesis) return;
+
+    setIsRefreshingSynthesis(true);
+    try {
+      await onRefreshSynthesis(messageIndex);
+      toast({
+        title: 'Synthesis refreshed',
+        description: 'Stage 2 + Stage 3 were recomputed from recovered Stage 1 responses.',
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : 'Failed to refresh synthesis';
+      toast({
+        title: 'Synthesis refresh failed',
+        description: detail,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsRefreshingSynthesis(false);
+    }
+  };
+
   return (
     <Card className="w-full border-2 border-transparent data-[state=chairman]:border-chairman/20 overflow-hidden">
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
@@ -437,6 +469,19 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
                       <Badge variant="secondary" className="text-xs">
                         {metadata.framework}
                       </Badge>
+                    )}
+                    {canRefreshSynthesis && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={handleRefreshSynthesis}
+                        disabled={isRefreshingSynthesis}
+                        aria-label="Refresh synthesis using latest Stage 1 results"
+                      >
+                        <RotateCcw className={cn('mr-1 h-3.5 w-3.5', isRefreshingSynthesis && 'animate-spin')} />
+                        {isRefreshingSynthesis ? 'Refreshing...' : 'Refresh synthesis'}
+                      </Button>
                     )}
                   </div>
                   {hasModelMetadata && (

--- a/frontend/src/components/MessageItem.jsx
+++ b/frontend/src/components/MessageItem.jsx
@@ -5,7 +5,7 @@ import CouncilMessageBlock from './CouncilMessageBlock';
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { User } from "lucide-react";
 
-const MessageItem = memo(({ msg, messageIndex, onRetryFailedModels }) => {
+const MessageItem = memo(({ msg, messageIndex, onRetryFailedModels, onRefreshSynthesis }) => {
   if (msg.role === 'user') {
     return (
       <div className="flex justify-end mb-6">
@@ -41,6 +41,7 @@ const MessageItem = memo(({ msg, messageIndex, onRetryFailedModels }) => {
             message={msg}
             messageIndex={messageIndex}
             onRetryFailedModels={onRetryFailedModels}
+            onRefreshSynthesis={onRefreshSynthesis}
           />
         </div>
       </div>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -186,3 +186,65 @@ async def test_retry_failed_stage1_models_without_failures_returns_400(async_cli
             assert response.json()["detail"] == "No failed models found to retry"
     finally:
         app.dependency_overrides = {}
+
+
+@pytest.mark.asyncio
+async def test_refresh_synthesis_after_retry_success(async_client):
+    conversation = {
+        "id": "conv-refresh",
+        "framework": "standard",
+        "council_models": ["model-a", "model-b"],
+        "chairman_model": "chair-model",
+        "messages": [
+            {"role": "user", "content": "How should we improve onboarding?"},
+            {
+                "role": "assistant",
+                "stage1": [
+                    {"model": "model-a", "response": "Use checklists."},
+                    {"model": "model-b", "response": "Add product tours."},
+                ],
+                "stage2": [],
+                "stage3": {"model": "chair-model", "response": "Start with tours then checklists."},
+                "metadata": {
+                    "framework": "standard",
+                    "effective_council_models": ["model-a", "model-b"],
+                    "requested_council_models": ["model-a", "model-b"],
+                    "chairman_model": "chair-model",
+                    "stage1_retry_history": [{"timestamp_ms": 1}],
+                },
+            },
+        ],
+    }
+
+    app.dependency_overrides[auth.get_current_user_id] = lambda: "test_user"
+    try:
+        with patch("backend.storage.get_conversation", new_callable=AsyncMock) as mock_get_conversation, \
+             patch("backend.storage.update_message", new_callable=AsyncMock) as mock_update_message, \
+             patch("backend.retrieval.build_retrieval_context", new_callable=AsyncMock) as mock_retrieval, \
+             patch("backend.main.stage2_collect_rankings", new_callable=AsyncMock) as mock_stage2_rankings, \
+             patch("backend.main.calculate_aggregate_rankings") as mock_aggregate, \
+             patch("backend.main.stage3_synthesize_final") as mock_stage3:
+            mock_get_conversation.return_value = conversation
+            mock_retrieval.return_value = ("retrieval", [{"id": "doc-1"}])
+            mock_stage2_rankings.return_value = ([{"model": "judge", "ranking": "FINAL RANKING:\n1. Response A\n2. Response B", "parsed_ranking": ["Response A", "Response B"]}], {"Response A": "model-a", "Response B": "model-b"})
+            mock_aggregate.return_value = [{"model": "model-a", "average_rank": 1.0, "rankings_count": 1}]
+
+            async def stage3_chunks(*args, **kwargs):
+                yield "Refreshed"
+                yield " synthesis"
+
+            mock_stage3.side_effect = stage3_chunks
+
+            response = await async_client.post(
+                "/api/conversations/conv-refresh/messages/1/refresh-synthesis",
+                json={}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["stage3"]["response"] == "Refreshed synthesis"
+            assert data["metadata"]["aggregate_rankings"][0]["model"] == "model-a"
+            assert data["metadata"]["retrieval"]["citations"] == [{"id": "doc-1"}]
+            assert mock_update_message.await_count == 1
+    finally:
+        app.dependency_overrides = {}


### PR DESCRIPTION
### Motivation
- Allow regenerating Stage 2 (rankings/critiques) and Stage 3 (synthesis) for an assistant message after recovering Stage 1 responses so users can produce an updated final answer without re-running Stage 1.
- Preserve conversation context, retrieval citations, and metadata while giving an explicit UI action to refresh outputs after retries.

### Description
- Added a backend endpoint `POST /api/conversations/{conversation_id}/messages/{message_index}/refresh-synthesis` implemented in `backend/main.py` that reuses stored Stage 1 responses, rebuilds retrieval context via `retrieval.build_retrieval_context`, recomputes Stage 2/Stage 3 (using `stage2_collect_*` and `stage3_synthesize_final`), updates metadata (`label_to_model`, `aggregate_rankings`, `synthesis_refresh_history`, `retrieval.citations`) and persists the updated message with `storage.update_message`.
- Added `RefreshSynthesisRequest` validation and safety checks to ensure the target is an assistant message with valid Stage 1 responses and matching user history.
- Frontend changes include `api.refreshSynthesis` in `frontend/src/api.js`, a new `handleRefreshSynthesis` callback in `frontend/src/App.jsx`, and plumbing through `ChatInterface` -> `MessageItem` -> `CouncilMessageBlock` to expose a per-message `Refresh synthesis` button with `aria-label="Refresh synthesis using latest Stage 1 results"`, loading state, and toast feedback.
- Updated the roadmap `Info/IMPROVEMENTS_ROADMAP.md` to mark the feature implemented and added a backend unit test `test_refresh_synthesis_after_retry_success` in `tests/test_api.py` to cover the flow.

### Testing
- Ran the relevant unit tests: `pytest -q tests/test_api.py::test_retry_failed_stage1_models_success tests/test_api.py::test_refresh_synthesis_after_retry_success` and both tests passed (`2 passed`).
- Ran frontend lint: `npm run lint` inside `frontend/` and it completed successfully.
- The new test mocks Stage 2/3 and asserts the endpoint returns refreshed `stage3.response`, updated `metadata.aggregate_rankings`, and that `storage.update_message` was called once.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e06a57388322951f1c87a57c8200)