### PR TITLE
feat(planner): add in-composer prompt snippets

### DIFF
--- a/Info/IMPROVEMENTS_ROADMAP.md
+++ b/Info/IMPROVEMENTS_ROADMAP.md
@@ -26,6 +26,11 @@ _Last updated: March 4, 2026_
 
 ## Follow-Up Queue
 
+- [x] In-composer prompt snippets
+  - Status: Implemented.
+  - Frontend:
+    - Added reusable prompt snippet chips directly above the message composer.
+    - Snippet selection pre-fills the input and keeps focus in the editor for quick edits.
 
 - [x] Guided “first prompt” onboarding
   - Status: Implemented.
@@ -61,6 +66,7 @@ _Last updated: March 4, 2026_
 
 ## Progress Log
 
+- 2026-03-05: Added in-composer prompt snippet chips (Decision Brief/Debug Plan/Risk Scan) to speed up repeat prompting workflows.
 - 2026-03-05: Added post-retry synthesis refresh endpoint + UI action to recompute Stage 2/3 from recovered Stage 1 responses.
 - 2026-03-05: Added granular Stage 1 retry UX with per-model retry actions and explicit retry outcome toasts.
 - 2026-03-05: Added guided “first prompt” onboarding with starter prompt quick picks, Alt+1/2/3 shortcuts, and send shortcut guidance in empty-state UI.

--- a/frontend/src/components/ChatInput.jsx
+++ b/frontend/src/components/ChatInput.jsx
@@ -8,6 +8,24 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { Badge } from "@/components/ui/badge";
 import { Paperclip, Send, X, FileText, Loader2 } from "lucide-react";
 
+const PROMPT_SNIPPETS = [
+  {
+    id: 'decision-brief',
+    label: 'Decision Brief',
+    prompt: 'Give me a concise decision brief with options, trade-offs, and a recommended next step.'
+  },
+  {
+    id: 'debug-plan',
+    label: 'Debug Plan',
+    prompt: 'Diagnose this issue step-by-step and propose the fastest path to a verified fix.'
+  },
+  {
+    id: 'risk-scan',
+    label: 'Risk Scan',
+    prompt: 'Perform a risk scan: list key risks, likelihood, impact, and practical mitigations.'
+  }
+];
+
 const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPrompt = '' }) => {
   const [input, setInput] = useState('');
   const [documents, setDocuments] = useState([]);
@@ -145,6 +163,12 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPro
     }
   };
 
+  const handleSnippetSelect = (prompt) => {
+    if (isLoading) return;
+    setInput(prompt);
+    textareaRef.current?.focus();
+  };
+
   return (
     <div className="border-t bg-background p-4">
       <form onSubmit={handleSubmit} className="mx-auto max-w-3xl flex flex-col gap-3">
@@ -188,6 +212,23 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPro
         )}
 
         {/* Input Area */}
+        <div className="flex flex-wrap gap-2" aria-label="Prompt starter snippets">
+          {PROMPT_SNIPPETS.map((snippet) => (
+            <Button
+              key={snippet.id}
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => handleSnippetSelect(snippet.prompt)}
+              disabled={isLoading}
+              className="h-7 rounded-full text-xs"
+              aria-label={`Insert ${snippet.label} snippet`}
+            >
+              {snippet.label}
+            </Button>
+          ))}
+        </div>
+
         <div className="relative flex items-end gap-2 rounded-lg border bg-background p-2 shadow-sm focus-within:ring-1 focus-within:ring-ring">
           {/* Attachment Button */}
           <TooltipProvider>


### PR DESCRIPTION
### Motivation
- Speed up common prompting workflows by surfacing quick-insert prompt snippets directly in the composer so users can prefill and edit common intents without leaving the input flow.
- Record the feature as completed in the project roadmap for traceability and progress tracking.

### Description
- Added a static `PROMPT_SNIPPETS` array and a `handleSnippetSelect` handler in `frontend/src/components/ChatInput.jsx` to prefill the composer with three snippet options (`Decision Brief`, `Debug Plan`, `Risk Scan`).
- Rendered snippet chips as semantic `Button` controls directly above the message composer with `aria-label`s and logic to preserve focus in the textarea after insertion.
- Updated `Info/IMPROVEMENTS_ROADMAP.md` to mark the in-composer prompt snippets follow-up as implemented and added a progress log entry.
- Small UX guard added to respect `isLoading` so snippets are disabled while a send is in progress.

### Testing
- Ran `npm run lint` in the `frontend/` workspace and it passed successfully.
- Performed an automated Playwright visual smoke run where the Firefox-based script completed and produced light/dark screenshots, while a Chromium launch failed with a renderer crash (SIGSEGV) during headless launch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e396bad88322a7a60f389f9b2eab)