### PR TITLE
feat(planner): add conversation-level draft recovery in composer

### DIFF
--- a/Info/IMPROVEMENTS_ROADMAP.md
+++ b/Info/IMPROVEMENTS_ROADMAP.md
@@ -64,8 +64,15 @@ _Last updated: March 4, 2026_
     - Added per-message `Refresh synthesis` action once Stage 1 retries exist.
     - Updates rankings, consensus output, and metadata in place after refresh.
 
+- [x] Composer draft recovery by conversation
+  - Status: Implemented.
+  - Frontend:
+    - Added per-conversation local draft persistence for unsent composer text.
+    - Restores saved drafts when returning to a conversation and surfaces a clear-draft action.
+
 ## Progress Log
 
+- 2026-03-05: Added per-conversation composer draft persistence + restore banner with a one-click clear action.
 - 2026-03-05: Added in-composer prompt snippet chips (Decision Brief/Debug Plan/Risk Scan) to speed up repeat prompting workflows.
 - 2026-03-05: Added post-retry synthesis refresh endpoint + UI action to recompute Stage 2/3 from recovered Stage 1 responses.
 - 2026-03-05: Added granular Stage 1 retry UX with per-model retry actions and explicit retry outcome toasts.

--- a/frontend/src/components/ChatInput.jsx
+++ b/frontend/src/components/ChatInput.jsx
@@ -26,12 +26,15 @@ const PROMPT_SNIPPETS = [
   }
 ];
 
+const DRAFT_STORAGE_KEY_PREFIX = 'llm-council:draft:';
+
 const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPrompt = '' }) => {
   const [input, setInput] = useState('');
   const [documents, setDocuments] = useState([]);
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [uploadError, setUploadError] = useState('');
+  const [draftRestored, setDraftRestored] = useState(false);
 
   const textareaRef = useRef(null);
   const fileInputRef = useRef(null);
@@ -49,8 +52,11 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPro
     setUploadError('');
     setUploading(false);
     setUploadProgress(0);
+    setDraftRestored(false);
+
     if (!conversationId) {
       setDocuments([]);
+      setInput('');
       return;
     }
 
@@ -65,6 +71,31 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPro
 
     loadDocuments();
   }, [conversationId]);
+
+  useEffect(() => {
+    if (!conversationId) return;
+
+    const storageKey = `${DRAFT_STORAGE_KEY_PREFIX}${conversationId}`;
+    const savedDraft = localStorage.getItem(storageKey);
+    if (savedDraft) {
+      setInput(savedDraft);
+      setDraftRestored(true);
+    }
+  }, [conversationId]);
+
+  useEffect(() => {
+    if (!conversationId) return;
+
+    const storageKey = `${DRAFT_STORAGE_KEY_PREFIX}${conversationId}`;
+    const trimmedInput = input.trim();
+
+    if (!trimmedInput) {
+      localStorage.removeItem(storageKey);
+      return;
+    }
+
+    localStorage.setItem(storageKey, input);
+  }, [conversationId, input]);
 
   useEffect(() => {
     if (!prefilledPrompt) return;
@@ -87,6 +118,10 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPro
     e.preventDefault();
     if (input.trim() && !isLoading) {
       onSendMessage(input);
+      if (conversationId) {
+        localStorage.removeItem(`${DRAFT_STORAGE_KEY_PREFIX}${conversationId}`);
+      }
+      setDraftRestored(false);
       setInput('');
       // Reset height
       if (textareaRef.current) textareaRef.current.style.height = "auto";
@@ -169,6 +204,14 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPro
     textareaRef.current?.focus();
   };
 
+  const handleClearDraft = () => {
+    if (!conversationId) return;
+    localStorage.removeItem(`${DRAFT_STORAGE_KEY_PREFIX}${conversationId}`);
+    setInput('');
+    setDraftRestored(false);
+    textareaRef.current?.focus();
+  };
+
   return (
     <div className="border-t bg-background p-4">
       <form onSubmit={handleSubmit} className="mx-auto max-w-3xl flex flex-col gap-3">
@@ -212,6 +255,15 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage, prefilledPro
         )}
 
         {/* Input Area */}
+        {draftRestored && (
+          <div className="flex items-center justify-between rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
+            <span>Draft restored for this conversation.</span>
+            <Button type="button" variant="ghost" size="sm" onClick={handleClearDraft} className="h-6 px-2 text-xs">
+              Clear draft
+            </Button>
+          </div>
+        )}
+
         <div className="flex flex-wrap gap-2" aria-label="Prompt starter snippets">
           {PROMPT_SNIPPETS.map((snippet) => (
             <Button


### PR DESCRIPTION
### Motivation
- Prevent loss of unsent composer text when switching conversations or refreshing the page by persisting drafts per conversation.
- Surface restored drafts to users and provide a simple clear action so restoration is explicit and reversible.

### Description
- Added local draft persistence in `frontend/src/components/ChatInput.jsx` using a `DRAFT_STORAGE_KEY_PREFIX` keyed by `conversationId` and a `draftRestored` state flag.
- Implemented effects to restore saved drafts on conversation load, persist input changes to `localStorage`, and remove persisted drafts after successful send or when clearing.
- Added a visible inline banner with a keyboard-accessible `Clear draft` button and updated `Info/IMPROVEMENTS_ROADMAP.md` to track the completed task.

### Testing
- Ran `npm run lint` in the `frontend` workspace and it passed with no errors.
- Ran `npm run build` and the Vite production build completed successfully (non-blocking chunk-size warning only).
- Launched the dev server and executed a Playwright smoke script to capture the UI state, which completed and produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e4fa69808322ab4810b9e6878979)