### PR TITLE
feat(planner): add copy actions for council outputs

### DIFF
--- a/Info/IMPROVEMENTS_ROADMAP.md
+++ b/Info/IMPROVEMENTS_ROADMAP.md
@@ -70,8 +70,15 @@ _Last updated: March 4, 2026_
     - Added per-conversation local draft persistence for unsent composer text.
     - Restores saved drafts when returning to a conversation and surfaces a clear-draft action.
 
+- [x] Quick-copy actions for consensus and model responses
+  - Status: Implemented.
+  - Frontend:
+    - Added copy-to-clipboard actions for the consensus pane and each individual Stage 1 model response.
+    - Added toast feedback for successful copy and clipboard access failures.
+
 ## Progress Log
 
+- 2026-03-05: Added one-click copy actions for consensus + Stage 1 model tabs with clipboard success/failure toasts.
 - 2026-03-05: Added per-conversation composer draft persistence + restore banner with a one-click clear action.
 - 2026-03-05: Added in-composer prompt snippet chips (Decision Brief/Debug Plan/Risk Scan) to speed up repeat prompting workflows.
 - 2026-03-05: Added post-retry synthesis refresh endpoint + UI action to recompute Stage 2/3 from recovered Stage 1 responses.

--- a/frontend/src/components/CouncilMessageBlock.jsx
+++ b/frontend/src/components/CouncilMessageBlock.jsx
@@ -6,7 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
-import { AlertTriangle, Trophy, Crown, BrainCircuit, GitCompareArrows, RotateCcw } from "lucide-react";
+import { AlertTriangle, Trophy, Crown, BrainCircuit, GitCompareArrows, RotateCcw, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // ⚡ Bolt: Memoize markdown rendering to prevent re-parsing on every parent re-render
@@ -52,10 +52,20 @@ const RankingsTabContent = memo(({ aggregateRankings }) => (
 RankingsTabContent.displayName = 'RankingsTabContent';
 
 // ⚡ Bolt: Extract and memoize Stage 1 tab content to keep individual responses stable during updates
-const Stage1TabContent = memo(({ res }) => (
+const Stage1TabContent = memo(({ res, onCopy }) => (
   <div className="p-6">
-    <div className="flex items-center gap-2 mb-4">
+    <div className="flex items-center gap-2 mb-4 flex-wrap">
       <Badge variant="outline">{res.model}</Badge>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 text-xs"
+        onClick={() => onCopy(res.response, `${res.model} response`)}
+        aria-label={`Copy ${res.model} response`}
+      >
+        <Copy className="mr-1 h-3.5 w-3.5" />
+        Copy
+      </Button>
     </div>
     <MarkdownContent content={res.response} />
   </div>
@@ -418,6 +428,31 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels, onRef
     }
   };
 
+  const copyToClipboard = async (value, label) => {
+    const text = typeof value === 'string' ? value.trim() : '';
+    if (!text) {
+      toast({
+        title: 'Nothing to copy',
+        description: `No ${label.toLowerCase()} content available yet.`,
+      });
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(text);
+      toast({
+        title: `${label} copied`,
+        description: `Copied ${label.toLowerCase()} to your clipboard.`,
+      });
+    } catch (error) {
+      toast({
+        title: 'Copy failed',
+        description: error instanceof Error ? error.message : 'Could not access clipboard.',
+        variant: 'destructive',
+      });
+    }
+  };
+
   return (
     <Card className="w-full border-2 border-transparent data-[state=chairman]:border-chairman/20 overflow-hidden">
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
@@ -483,6 +518,18 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels, onRef
                         {isRefreshingSynthesis ? 'Refreshing...' : 'Refresh synthesis'}
                       </Button>
                     )}
+                    {hasStage3 && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => copyToClipboard(stage3.response, 'Consensus')}
+                        aria-label="Copy consensus response"
+                      >
+                        <Copy className="mr-1 h-3.5 w-3.5" />
+                        Copy consensus
+                      </Button>
+                    )}
                   </div>
                   {hasModelMetadata && (
                     <div className="mb-4 space-y-1 text-xs text-muted-foreground">
@@ -526,7 +573,7 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels, onRef
 
           {hasStage1 && stage1.map((res, idx) => (
             <TabsContent key={idx} value={`model-${idx}`} className="m-0 focus-visible:ring-0">
-              <Stage1TabContent res={res} />
+              <Stage1TabContent res={res} onCopy={copyToClipboard} />
             </TabsContent>
           ))}
         </div>


### PR DESCRIPTION
### Motivation
- Users frequently copy council outputs into docs or follow-up prompts, so one-click copy actions reduce friction and context-switching.
- The change also provides explicit feedback for clipboard availability and empty content to improve UX.

### Description
- Imported the `Copy` icon and added copy buttons for the consensus pane and each Stage 1 model response in `frontend/src/components/CouncilMessageBlock.jsx`.
- Added a shared `copyToClipboard` helper that trims content and shows success, empty-content, and error toasts using the existing `useToast` system.
- Updated `Stage1TabContent` to accept an `onCopy` prop and wired Stage 1 tabs and the consensus header to call the shared copy handler.
- Marked the roadmap task complete in `Info/IMPROVEMENTS_ROADMAP.md` and added a progress-log entry for the change.

### Testing
- Ran `npm --prefix frontend run lint` and it passed with no reported lint errors.
- Ran `npm --prefix frontend run build` (production build via `vite build`) and it completed successfully.
- Launched the dev server and captured a homepage screenshot via an automated Playwright script to validate the UI served correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e869c0d883228f9ccb80affc0fa9)