### PR TITLE
🧹 Move module-level import to top

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Any, Dict
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy import String, DateTime, JSON, text, Integer, Text, Index
+from sqlalchemy.engine.url import make_url
 from .config import DATABASE_URL
 
 # --- Database Setup ---
@@ -73,8 +74,6 @@ class DocumentChunkModel(Base):
 # Only create engine if DATABASE_URL is set
 engine = None
 AsyncSessionLocal = None
-
-from sqlalchemy.engine.url import make_url
 
 def configure_ssl_context(query_params: dict):
     """


### PR DESCRIPTION
🎯 **What:** The mid-file import of `make_url` in `backend/database.py` was moved to the top of the file.
💡 **Why:** This improves maintainability and follows PEP 8 code style guidelines by keeping all module-level imports in one place.
✅ **Verification:** Confirmed the change by running the full backend test suite (`uv run pytest`), which passed all 86 tests.
✨ **Result:** Improved code readability and adherence to Python coding standards.

---
*PR created automatically by Jules for task [3464525730891888826](https://jules.google.com/task/3464525730891888826) started by @ashwathravi*