### PR TITLE
🔒 [security fix] Enforce PostgreSQL SSL Certificate Verification

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -82,30 +82,35 @@ def configure_ssl_context(query_params: dict):
     Returns (connect_args_dict, updated_query_params).
     """
     connect_args = {}
+    ssl_root_cert = query_params.pop("sslrootcert", None)
+
     if "sslmode" in query_params:
         ssl_mode = query_params.pop("sslmode")
+        ssl_context = None
 
         # Verify-Full: Strict verification (Certificate + Hostname)
         if ssl_mode == "verify-full":
             ssl_context = ssl.create_default_context()
             ssl_context.check_hostname = True
             ssl_context.verify_mode = ssl.CERT_REQUIRED
-            connect_args["ssl"] = ssl_context
 
         # Verify-CA: Verify Certificate only (No hostname check)
         elif ssl_mode == "verify-ca":
             ssl_context = ssl.create_default_context()
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_REQUIRED
-            connect_args["ssl"] = ssl_context
 
         # Require: Encryption required, but verification optional (Legacy/Compat)
         elif ssl_mode == "require":
-            # Create a custom SSL context to avoid certificate verification errors
-            # which are common in some deployment environments (e.g. Render, self-signed)
+            # Encryption with certificate verification to prevent MITM.
+            # Hostname check is disabled for compatibility with some cloud providers.
             ssl_context = ssl.create_default_context()
             ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+
+        if ssl_context:
+            if ssl_root_cert:
+                ssl_context.load_verify_locations(cafile=ssl_root_cert)
             connect_args["ssl"] = ssl_context
 
     return connect_args, query_params

--- a/tests/test_db_ssl.py
+++ b/tests/test_db_ssl.py
@@ -31,17 +31,33 @@ def test_verify_ca_is_secure_cert_only():
     assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is False
 
-def test_require_is_still_lenient():
+def test_require_is_secure():
     """
-    Asserts that sslmode=require remains lenient (CERT_NONE) for compatibility.
+    Asserts that sslmode=require is now secure (CERT_REQUIRED) but without hostname check.
     """
     query_params = {"sslmode": "require"}
     connect_args, updated_params = configure_ssl_context(query_params)
 
     ctx = connect_args.get("ssl")
     assert ctx is not None
-    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is False
+
+def test_sslrootcert_loading():
+    """
+    Asserts that sslrootcert is correctly handled and loaded into the context.
+    """
+    from unittest.mock import patch, MagicMock
+
+    query_params = {"sslmode": "verify-ca", "sslrootcert": "/path/to/ca.crt"}
+
+    with patch("ssl.SSLContext.load_verify_locations") as mock_load:
+        connect_args, updated_params = configure_ssl_context(query_params)
+
+        ctx = connect_args.get("ssl")
+        assert ctx is not None
+        mock_load.assert_called_once_with(cafile="/path/to/ca.crt")
+        assert "sslrootcert" not in updated_params
 
 def test_no_sslmode():
     """


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Insecure PostgreSQL SSL configuration where `sslmode="require"` was set to bypass certificate verification (`ssl.CERT_NONE`).

⚠️ **Risk:** The potential impact if left unfixed
Connections to the database over untrusted networks could be intercepted or modified via Man-in-the-Middle (MITM) attacks, as the application would accept any certificate presented by the server.

🛡️ **Solution:** How the fix addresses the vulnerability
- Changed `sslmode="require"` to use `ssl.CERT_REQUIRED`, ensuring that the server's certificate is always verified against a trusted CA.
- Added support for the `sslrootcert` query parameter, allowing users to specify a custom CA certificate file. This provides a secure way for users to connect to databases that use self-signed certificates or private CAs.
- Updated the test suite to enforce these new security requirements and verify the `sslrootcert` functionality.

---
*PR created automatically by Jules for task [8104137687435577466](https://jules.google.com/task/8104137687435577466) started by @ashwathravi*