### PR TITLE
[codex] update AGENTS.md workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Workflows
+
+### Local development
+- Install dependencies: `uv sync` and `cd frontend && npm install`
+- Bootstrap Codex environment: `./codex_setup.sh`
+- Bootstrap Jules environment: `./jules_setup.sh`
+- Run both services: `./start.sh`
+- Run backend only: `uv run python -m backend.main`
+- Run frontend only: `cd frontend && npm run dev`
+
+### Validation
+- Run backend tests: `uv run pytest`
+- Lint frontend: `cd frontend && npm run lint`
+- Build frontend: `cd frontend && npm run build`
+- Preview production frontend build: `cd frontend && npm run preview`
+
+### Utility scripts
+- Export benchmark script: `python scripts/benchmark_export.py`
+- Retrieval benchmark script: `python scripts/measure_retrieval.py`
+- Add DB index migration: `uv run python scripts/add_index.py`
+- Scout assigned GitHub issues into `.agent/passports`: `gh auth login && ./scripts/scout_agent.py`
+
+### Agentic workflow bootstrap
+- Create a new feature passport: `cp .agent/templates/feature_passport.md .agent/passports/my_feature.md`
+
+### Container workflow
+- Build and run with Docker Compose: `docker compose up --build`
+
+## TODO
+- Confirm whether utility scripts should be run via `uv run python ...` for environment consistency.


### PR DESCRIPTION
## Summary
This change adds a repository-local `AGENTS.md` file for the current worktree and records only the workflows and commands that are directly discoverable from the repo. The practical effect is that future agent runs have an explicit, checked-in command reference instead of relying on scattered docs or cross-worktree state.

## Problem
The worktree did not contain an `AGENTS.md`, even though this automation is responsible for keeping that file current. Without a local file, agent instructions drift across worktrees and newly discovered commands are easy to miss or re-invent.

## Root Cause
The previous automation run created `AGENTS.md` in a different worktree, so this checkout still lacked the file. In addition, a few repo-backed commands were present in scripts and docs but were not yet captured in the current worktree's agent guidance.

## Fix
The new `AGENTS.md` keeps the existing baseline entries for local development, validation, utility scripts, and Docker usage, and adds only repo-grounded commands discovered in the current checkout: bootstrap helpers (`./codex_setup.sh`, `./jules_setup.sh`), the database index migration script (`uv run python scripts/add_index.py`), the scout workflow (`gh auth login && ./scripts/scout_agent.py`), and the passport bootstrap command (`cp .agent/templates/feature_passport.md .agent/passports/my_feature.md`). The existing TODO about whether utility scripts should consistently use `uv run python` was retained rather than guessing.

## Validation
I verified the commands against tracked repo files, including `Info/README.md`, `.agent/AGENTIC_WORKFLOW_README.md`, `pyproject.toml`, `start.sh`, `codex_setup.sh`, `jules_setup.sh`, `frontend/package.json`, and the scripts under `scripts/`. No code tests were run because the change is documentation-only.
