### PR TITLE
🧪 Add edge case tests for parse_ranking_from_text

### DIFF
--- a/tests/test_ranking_parser.py
+++ b/tests/test_ranking_parser.py
@@ -68,3 +68,42 @@ def test_case_sensitivity():
 def test_varied_whitespace():
     text = "FINAL RANKING: 1.Response A, 2.  Response B"
     assert parse_ranking_from_text(text) == ["Response A", "Response B"]
+
+def test_missing_colon_in_marker():
+    # If colon is missing, marker "FINAL RANKING:" isn't found, should fallback to whole text search
+    text = """
+    FINAL RANKING
+    1. Response B
+    2. Response A
+    """
+    # Since "FINAL RANKING:" (with colon) is not found, it uses the fallback which finds all Response [A-Z]
+    assert parse_ranking_from_text(text) == ["Response B", "Response A"]
+
+def test_duplicate_responses():
+    # Test that duplicate mentions are preserved in the order they appear
+    text = "FINAL RANKING: 1. Response A, 2. Response A, 3. Response B"
+    assert parse_ranking_from_text(text) == ["Response A", "Response A", "Response B"]
+
+def test_multiple_markers():
+    # Test that the parser starts from the first "FINAL RANKING:" marker
+    text = """
+    FINAL RANKING:
+    1. Response A
+
+    Wait, I changed my mind.
+    FINAL RANKING:
+    1. Response B
+    """
+    # It finds everything after the FIRST "FINAL RANKING:"
+    # numbered_matches will find "1. Response A" and "1. Response B"
+    assert parse_ranking_from_text(text) == ["Response A", "Response B"]
+
+def test_empty_ranking_section():
+    # Ensure the parser returns an empty list if no "Response X" patterns are found after the marker
+    text = "FINAL RANKING: No responses were good enough to rank."
+    assert parse_ranking_from_text(text) == []
+
+def test_lowercase_response_label():
+    # Ensure "response a" is correctly normalized to "Response A"
+    text = "FINAL RANKING: 1. response a, 2. Response B"
+    assert parse_ranking_from_text(text) == ["Response A", "Response B"]


### PR DESCRIPTION
I have implemented several new test cases for the `parse_ranking_from_text` function in `backend/council.py`. 

🎯 **What:** The testing gap addressed was a lack of coverage for common edge cases in LLM-generated ranking sections.
📊 **Coverage:** The new tests cover scenarios like missing colons in markers, duplicate entries, multiple ranking markers (e.g., when a model re-thinks), empty sections, and case-insensitive label normalization.
✨ **Result:** Improved reliability and confidence in the ranking extraction logic, ensuring it handles messy model outputs gracefully.

All tests (old and new) passed successfully.

---
*PR created automatically by Jules for task [15256121426102799281](https://jules.google.com/task/15256121426102799281) started by @ashwathravi*