### PR TITLE
🧹 replace direct console.error with logging utility

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback, lazy, Suspense, useMemo } from 'react
 import CouncilSidebar from './components/CouncilSidebar';
 import ChatInterface from './components/ChatInterface';
 import { api } from './api';
+import { logger } from '@/lib/logger';
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/toaster";
 import { useToast } from "@/components/ui/use-toast";
@@ -43,7 +44,7 @@ function App() {
       const convs = await api.listConversations();
       setConversations(convs);
     } catch (error) {
-      console.error('Failed to load conversations:', error);
+      logger.error('Failed to load conversations:', error);
       if (error.message.includes('401') || error.message.includes('Unauthorized')) {
         logout();
       }
@@ -55,7 +56,7 @@ function App() {
       const conv = await api.getConversation(id);
       setCurrentConversation(conv);
     } catch (error) {
-      console.error('Failed to load conversation:', error);
+      logger.error('Failed to load conversation:', error);
     }
   }, []);
 
@@ -124,7 +125,7 @@ function App() {
       window.history.pushState({ path: newUrl }, '', newUrl);
       return data;
     } catch (error) {
-      console.error('Failed to create conversation:', error);
+      logger.error('Failed to create conversation:', error);
       throw error;
     } finally {
       setIsLoading(false);
@@ -333,7 +334,7 @@ function App() {
             setIsLoading(false);
             break;
           case 'error':
-            console.error('Stream error:', event.error);
+            logger.error('Stream error:', event.error);
             setCurrentConversation((prev) => {
               const messages = [...prev.messages];
               const lastIndex = messages.length - 1;
@@ -369,7 +370,7 @@ function App() {
         }
       });
     } catch (error) {
-      console.error('Failed to send message:', error);
+      logger.error('Failed to send message:', error);
       setCurrentConversation((prev) => ({
         ...prev,
         messages: prev.messages.slice(0, -2),

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,7 @@
 /**
  * API client for the LLM Council backend.
  */
+import { logger } from '@/lib/logger';
 
 // Use localhost in development, relative path in production (same origin)
 const API_BASE = import.meta.env.DEV ? 'http://localhost:8001' : '';
@@ -243,7 +244,7 @@ export const api = {
               }
               onEvent(event.type, event);
             } catch (e) {
-              console.error('Failed to parse SSE event:', e);
+              logger.error('Failed to parse SSE event:', e);
             }
           }
         }
@@ -258,11 +259,11 @@ export const api = {
           }
           onEvent(event.type, event);
         } catch (e) {
-          console.error('Failed to parse (final) SSE event:', e);
+          logger.error('Failed to parse (final) SSE event:', e);
         }
       }
     } catch (error) {
-      console.error('SSE stream failed:', error);
+      logger.error('SSE stream failed:', error);
       if (!receivedTerminalEvent) {
         onEvent('error', {
           type: 'error',

--- a/frontend/src/components/ChatHeader.jsx
+++ b/frontend/src/components/ChatHeader.jsx
@@ -1,6 +1,7 @@
 
 import React, { memo } from 'react';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Download, Link as LinkIcon, FileText, Check, ListTree } from "lucide-react";
@@ -44,7 +45,7 @@ const ChatHeader = memo(({
         description: `Exporting conversation to ${format.toUpperCase()}...`,
       });
     } catch (error) {
-      console.error('Export failed:', error);
+      logger.error('Export failed:', error);
       toast({
         variant: "destructive",
         title: "Export Failed",
@@ -63,7 +64,7 @@ const ChatHeader = memo(({
       });
       setTimeout(() => setCopied(false), 2000);
     }).catch(err => {
-      console.error('Failed to copy link:', err);
+      logger.error('Failed to copy link:', err);
       toast({
         variant: "destructive",
         title: "Error",

--- a/frontend/src/components/ChatInput.jsx
+++ b/frontend/src/components/ChatInput.jsx
@@ -1,6 +1,7 @@
 
 import React, { memo, useState, useEffect, useRef } from 'react';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -41,7 +42,7 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage }) => {
         const docs = await api.listDocuments(conversationId);
         setDocuments(docs);
       } catch (error) {
-        console.error('Failed to load documents:', error);
+        logger.error('Failed to load documents:', error);
       }
     };
 
@@ -106,7 +107,7 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage }) => {
       const updatedDocuments = await api.listDocuments(conversationId);
       setDocuments(updatedDocuments);
     } catch (error) {
-      console.error('Upload failed:', error);
+      logger.error('Upload failed:', error);
       setUploadError('Failed to upload documents.');
     } finally {
       setUploading(false);

--- a/frontend/src/components/CouncilSidebar.jsx
+++ b/frontend/src/components/CouncilSidebar.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, memo } from 'react';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
@@ -49,7 +50,7 @@ const readSavedPresets = () => {
         };
       });
   } catch (error) {
-    console.error('Failed to parse presets', error);
+    logger.error('Failed to parse presets', error);
     return [];
   }
 };
@@ -62,7 +63,7 @@ const readFavoriteModels = () => {
     if (!Array.isArray(parsed)) return [];
     return parsed.filter((id) => typeof id === 'string');
   } catch (error) {
-    console.error('Failed to parse favorite models', error);
+    logger.error('Failed to parse favorite models', error);
     return [];
   }
 };
@@ -188,7 +189,7 @@ const CouncilSidebar = memo(({
             .filter((modelId) => availableModelIds.has(modelId))
         );
       } catch (error) {
-        console.error('Failed to load models', error);
+        logger.error('Failed to load models', error);
       }
     };
 
@@ -362,7 +363,7 @@ const CouncilSidebar = memo(({
       setShowConfigDialog(false);
       if (isMobile) onClose();
     } catch (error) {
-      console.error('Failed to create conversation', error);
+      logger.error('Failed to create conversation', error);
       alert('Failed to start a new session. Please try again.');
     } finally {
       setIsCreatingSession(false);

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { GoogleLogin, GoogleOAuthProvider } from '@react-oauth/google';
 import { useAuth } from '../contexts/AuthContextDefinition';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { BrainCircuit } from "lucide-react";
 
@@ -24,7 +25,7 @@ export default function Login() {
                     setGoogleClientId(runtimeClientId);
                 }
             } catch (err) {
-                console.error('Failed to load auth config:', err);
+                logger.error('Failed to load auth config:', err);
             } finally {
                 if (isMounted) {
                     setIsConfigLoading(false);
@@ -54,7 +55,7 @@ export default function Login() {
             const data = await api.login(credentialResponse.credential);
             handleLoginSuccess(data);
         } catch (err) {
-            console.error('Login error:', err);
+            logger.error('Login error:', err);
             setError('Failed to log in with server');
             setIsLoading(false);
         }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, memo } from 'react';
 import './Sidebar.css';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import ModelSelect from './ModelSelect';
 
 const Sidebar = memo(({
@@ -37,7 +38,7 @@ const Sidebar = memo(({
       const s = await api.getStatus();
       setStatus(s);
     } catch (e) {
-      console.error("Failed to load status", e);
+      logger.error("Failed to load status", e);
       setStatusError("Error");
     }
   };
@@ -52,7 +53,7 @@ const Sidebar = memo(({
       // Ideally backend defaults should be visible but we don't know them easily without fetching config
       // Let's leave empty and let user know "Default" is used if empty
     } catch (error) {
-      console.error("Failed to load models", error);
+      logger.error("Failed to load models", error);
       setModelsError(error.message || "Failed to load models");
     } finally {
       setLoadingModels(false);
@@ -77,7 +78,7 @@ const Sidebar = memo(({
       // Since we don't have 'onDelete' prop yet, let's ask user to refresh or reload window.
       window.location.reload();
     } catch (err) {
-      console.error("Failed to delete", err);
+      logger.error("Failed to delete", err);
       alert("Failed to delete conversation");
     }
   };

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { AuthContext } from './AuthContextDefinition';
+import { logger } from '@/lib/logger';
 
 export { AuthContext };
 
@@ -23,7 +24,7 @@ export const AuthProvider = ({ children }) => {
         // Dynamically import googleLogout to avoid bundling @react-oauth/google in main chunk
         import('@react-oauth/google').then(({ googleLogout }) => {
             googleLogout();
-        }).catch(err => console.error("Failed to load googleLogout", err));
+        }).catch(err => logger.error("Failed to load googleLogout", err));
 
         setToken(null);
         setUser(null);

--- a/frontend/src/lib/logger.js
+++ b/frontend/src/lib/logger.js
@@ -1,0 +1,26 @@
+const isDev = import.meta.env.DEV;
+
+export const logger = {
+    error: (...args) => {
+        if (isDev) {
+            console.error(...args);
+        }
+    },
+    warn: (...args) => {
+        if (isDev) {
+            console.warn(...args);
+        }
+    },
+    log: (...args) => {
+        if (isDev) {
+            console.log(...args);
+        }
+    },
+    info: (...args) => {
+        if (isDev) {
+            console.info(...args);
+        }
+    }
+};
+
+export default logger;


### PR DESCRIPTION
The task was to remove leftover `console.error` statements from the production code. 

I implemented a centralized logging utility `frontend/src/lib/logger.js` that leverages Vite's `import.meta.env.DEV` to ensure that console output is only enabled during development.

Key changes:
- Created `frontend/src/lib/logger.js` which exports an object with `error`, `warn`, `log`, and `info` methods.
- Updated `frontend/src/api.js`, `frontend/src/App.jsx`, `frontend/src/components/Login.jsx`, and other components to use `logger.error` instead of `console.error`.
- Verified the changes by running `npm run lint` and `npm run build` in the `frontend` directory.
- Confirmed that no other `console.log` or `console.error` calls remain in the `src` directory, except within the logger utility itself.

---
*PR created automatically by Jules for task [14048885018622309077](https://jules.google.com/task/14048885018622309077) started by @ashwathravi*