### PR TITLE
🔒 security fix: remove insecure JWT secret fallback

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,7 +1,6 @@
 """Authentication module for Google Sign-In and JWT management."""
 
 import os
-import sys
 import jwt
 import logging
 from typing import Dict, Any, Optional
@@ -10,7 +9,6 @@ from google.oauth2 import id_token
 from google.auth.transport import requests
 from fastapi import HTTPException, status, Header, Depends
 from pydantic import BaseModel
-from .config import APP_ORIGIN
 from . import config
 
 # Setup logging
@@ -23,21 +21,11 @@ jwt_secret = os.getenv("JWT_SECRET_KEY")
 if jwt_secret:
     SECRET_KEY = jwt_secret
 else:
-    if APP_ORIGIN == "local":
-        SECRET_KEY = "dev_secret_key_change_in_production"
-        # Log warning (and print to stderr to ensure visibility during startup)
-        logger.warning("JWT_SECRET_KEY is not set. Using insecure default key.")
-        print(
-            "WARNING: JWT_SECRET_KEY is not set. Using insecure default key. "
-            "This is unsafe for production!",
-            file=sys.stderr
-        )
-    else:
-        # In production (Render, Replit, etc.), fail fast if no secret is set
-        raise RuntimeError(
-            f"CRITICAL SECURITY ERROR: JWT_SECRET_KEY is missing in {APP_ORIGIN} environment. "
-            "You must set a secure random string for JWT_SECRET_KEY to start the application."
-        )
+    # Fail fast if no secret is set across all environments
+    raise RuntimeError(
+        "CRITICAL SECURITY ERROR: JWT_SECRET_KEY is missing. "
+        "You must set a secure random string for JWT_SECRET_KEY to start the application."
+    )
 
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "8000:8000"
     environment:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-dev_secret_key_change_in_production}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
     volumes:
       - ./data:/app/data

--- a/reproduce_vulnerability.py
+++ b/reproduce_vulnerability.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+# Ensure backend can be imported
+sys.path.append(os.getcwd())
+
+def test_vulnerability():
+    # Ensure JWT_SECRET_KEY is NOT set
+    if "JWT_SECRET_KEY" in os.environ:
+        del os.environ["JWT_SECRET_KEY"]
+
+    # Also ensure APP_ORIGIN is local for the test (it is by default in this env)
+    os.environ["RENDER"] = ""
+    os.environ["REPLIT_ID"] = ""
+
+    try:
+        from backend import auth
+        expected_insecure_key = "dev_secret_key_change_in_production"
+        if auth.SECRET_KEY == expected_insecure_key:
+            print(f"VULNERABILITY CONFIRMED: SECRET_KEY is set to '{auth.SECRET_KEY}' when JWT_SECRET_KEY is missing.")
+            return True
+        else:
+            print(f"VULNERABILITY NOT FOUND: SECRET_KEY is '{auth.SECRET_KEY}'")
+            return False
+    except RuntimeError as e:
+        print(f"VULNERABILITY FIXED: Application raised RuntimeError as expected: {e}")
+        return False
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return False
+
+if __name__ == "__main__":
+    if test_vulnerability():
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,10 @@
 import pytest
 import pytest_asyncio
 import os
+
+# Set dummy secret key for tests before importing backend modules
+os.environ.setdefault("JWT_SECRET_KEY", "test_only_dummy_secret_key_for_unit_tests")
+
 from httpx import AsyncClient, ASGITransport
 from backend.main import app
 

--- a/tests/verify_live_api.py
+++ b/tests/verify_live_api.py
@@ -6,7 +6,10 @@ import os
 from datetime import datetime, timedelta
 
 # Configuration matched to backend/auth.py
-SECRET_KEY = os.getenv("JWT_SECRET_KEY", "dev_secret_key_change_in_production")
+SECRET_KEY = os.getenv("JWT_SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("JWT_SECRET_KEY environment variable is required for tests.")
+
 ALGORITHM = "HS256"
 API_URL = "http://localhost:8001/api"
 


### PR DESCRIPTION
Fixed a security vulnerability where an insecure default string was used as a fallback for `JWT_SECRET_KEY` in local environments. The fix enforces the presence of `JWT_SECRET_KEY` in the environment across all deployment scenarios.

### Changes:
- **`backend/auth.py`**: Removed `if APP_ORIGIN == "local"` fallback and implemented a mandatory check for `JWT_SECRET_KEY` that raises `RuntimeError` if not found.
- **`docker-compose.yml`**: Removed the hardcoded insecure default value.
- **`tests/verify_live_api.py`**: Updated to raise an error if the secret key is missing.
- **`tests/conftest.py`**: Injected a dummy secret key for unit tests to maintain test suite functionality.
- **`reproduce_vulnerability.py`**: Added a script to confirm the fix.

🎯 **What:** The vulnerability fixed was an insecure JWT secret fallback.
⚠️ **Risk:** If left unfixed, an attacker could potentially forge JWTs in local or misconfigured environments using the publicly known default key.
🛡️ **Solution:** Enforced that `JWT_SECRET_KEY` must be explicitly provided in the environment, causing the application to fail fast otherwise.

---
*PR created automatically by Jules for task [2966429478884589606](https://jules.google.com/task/2966429478884589606) started by @ashwathravi*