### PR TITLE
⚡ Optimize db_delete_document by removing redundant query

### DIFF
--- a/backend/storage.py
+++ b/backend/storage.py
@@ -269,18 +269,7 @@ async def db_get_document_chunks_by_ids(conversation_id: str, user_id: str, chun
 
 async def db_delete_document(conversation_id: str, document_id: str, user_id: str):
     async with AsyncSessionLocal() as session:
-        result = await session.execute(
-            select(DocumentModel)
-            .where(
-                DocumentModel.id == document_id,
-                DocumentModel.conversation_id == conversation_id,
-                DocumentModel.user_id == user_id
-            )
-        )
-        doc = result.scalar_one_or_none()
-        if not doc:
-            raise ValueError("Unauthorized or not found")
-
+        # Delete chunks first (no cascade)
         await session.execute(
             delete(DocumentChunkModel)
             .where(
@@ -289,7 +278,21 @@ async def db_delete_document(conversation_id: str, document_id: str, user_id: st
                 DocumentChunkModel.user_id == user_id
             )
         )
-        await session.delete(doc)
+
+        # Delete the document directly and check rowcount for existence/auth
+        result = await session.execute(
+            delete(DocumentModel)
+            .where(
+                DocumentModel.id == document_id,
+                DocumentModel.conversation_id == conversation_id,
+                DocumentModel.user_id == user_id
+            )
+        )
+
+        if result.rowcount == 0:
+            await session.rollback()
+            raise ValueError("Unauthorized or not found")
+
         await session.commit()
 
 def _model_to_dict(model: ConversationModel) -> Dict[str, Any]:

--- a/scripts/benchmark_mock_delete.py
+++ b/scripts/benchmark_mock_delete.py
@@ -1,0 +1,130 @@
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+from sqlalchemy import select, delete
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+# Mocking the models for the benchmark using SQLAlchemy DeclarativeBase
+class Base(DeclarativeBase):
+    pass
+
+class DocumentModel(Base):
+    __tablename__ = "documents"
+    id: Mapped[str] = mapped_column(primary_key=True)
+    conversation_id: Mapped[str] = mapped_column()
+    user_id: Mapped[str] = mapped_column()
+
+class DocumentChunkModel(Base):
+    __tablename__ = "document_chunks"
+    id: Mapped[str] = mapped_column(primary_key=True)
+    document_id: Mapped[str] = mapped_column()
+    conversation_id: Mapped[str] = mapped_column()
+    user_id: Mapped[str] = mapped_column()
+
+LATENCY = 0.01  # 10ms simulated latency per DB roundtrip
+
+async def simulated_delay(*args, **kwargs):
+    await asyncio.sleep(LATENCY)
+
+async def mock_execute(statement, *args, **kwargs):
+    await asyncio.sleep(LATENCY)
+    mock_result = MagicMock()
+    # If it's a select, return a mock object
+    if "SELECT" in str(statement).upper():
+        mock_result.scalar_one_or_none.return_value = MagicMock()
+    # If it's a delete, return rowcount = 1
+    elif "DELETE" in str(statement).upper():
+        mock_result.rowcount = 1
+    return mock_result
+
+async def current_logic(conversation_id, document_id, user_id, session):
+    # Roundtrip 1: Select
+    result = await session.execute(
+        select(DocumentModel)
+        .where(
+            DocumentModel.id == document_id,
+            DocumentModel.conversation_id == conversation_id,
+            DocumentModel.user_id == user_id
+        )
+    )
+    doc = result.scalar_one_or_none()
+    if not doc:
+        raise ValueError("Unauthorized or not found")
+
+    # Roundtrip 2: Delete Chunks
+    await session.execute(
+        delete(DocumentChunkModel)
+        .where(
+            DocumentChunkModel.document_id == document_id,
+            DocumentChunkModel.conversation_id == conversation_id,
+            DocumentChunkModel.user_id == user_id
+        )
+    )
+
+    # Roundtrip 3: Delete Document
+    await session.delete(doc)
+    # Roundtrip 4: Commit
+    await session.commit()
+
+async def optimized_logic(conversation_id, document_id, user_id, session):
+    # Roundtrip 1: Delete Chunks
+    await session.execute(
+        delete(DocumentChunkModel)
+        .where(
+            DocumentChunkModel.document_id == document_id,
+            DocumentChunkModel.conversation_id == conversation_id,
+            DocumentChunkModel.user_id == user_id
+        )
+    )
+
+    # Roundtrip 2: Delete Document with rowcount check
+    result = await session.execute(
+        delete(DocumentModel)
+        .where(
+            DocumentModel.id == document_id,
+            DocumentModel.conversation_id == conversation_id,
+            DocumentModel.user_id == user_id
+        )
+    )
+
+    if result.rowcount == 0:
+        await session.rollback()
+        raise ValueError("Unauthorized or not found")
+
+    # Roundtrip 3: Commit
+    await session.commit()
+
+async def run_benchmark():
+    num_iterations = 50
+    print(f"Benchmarking with {LATENCY*1000}ms simulated latency...")
+
+    # Benchmark Current
+    start = time.perf_counter()
+    for _ in range(num_iterations):
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=mock_execute)
+        session.commit = AsyncMock(side_effect=simulated_delay)
+        session.delete = AsyncMock(side_effect=simulated_delay)
+        await current_logic("conv", "doc", "user", session)
+    end = time.perf_counter()
+    avg_current = (end - start) / num_iterations
+    print(f"Current logic avg time: {avg_current:.4f}s")
+
+    # Benchmark Optimized
+    start = time.perf_counter()
+    for _ in range(num_iterations):
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=mock_execute)
+        session.commit = AsyncMock(side_effect=simulated_delay)
+        await optimized_logic("conv", "doc", "user", session)
+    end = time.perf_counter()
+    avg_optimized = (end - start) / num_iterations
+    print(f"Optimized logic avg time: {avg_optimized:.4f}s")
+
+    improvement = (avg_current - avg_optimized) / avg_current * 100
+    print(f"Improvement: {improvement:.2f}%")
+    print(f"Roundtrips saved: {round((avg_current - avg_optimized) / LATENCY)}")
+
+if __name__ == "__main__":
+    asyncio.run(run_benchmark())

--- a/tests/verify_db_delete_optimization.py
+++ b/tests/verify_db_delete_optimization.py
@@ -1,0 +1,47 @@
+
+import pytest
+import uuid
+from unittest.mock import AsyncMock, patch, MagicMock
+from backend import storage
+from backend.database import DocumentModel, DocumentChunkModel
+
+@pytest.mark.asyncio
+async def test_db_delete_document_success():
+    # Mock AsyncSessionLocal and its session
+    mock_session = AsyncMock()
+    mock_session_cm = AsyncMock()
+    mock_session_cm.__aenter__.return_value = mock_session
+
+    # Mock delete results
+    mock_result_chunks = MagicMock()
+    mock_result_doc = MagicMock()
+    mock_result_doc.rowcount = 1  # Success
+
+    mock_session.execute.side_effect = [mock_result_chunks, mock_result_doc]
+
+    with patch("backend.storage.AsyncSessionLocal", return_value=mock_session_cm):
+        await storage.db_delete_document("conv1", "doc1", "user1")
+
+    assert mock_session.commit.called
+    assert not mock_session.rollback.called
+
+@pytest.mark.asyncio
+async def test_db_delete_document_unauthorized_or_not_found():
+    # Mock AsyncSessionLocal and its session
+    mock_session = AsyncMock()
+    mock_session_cm = AsyncMock()
+    mock_session_cm.__aenter__.return_value = mock_session
+
+    # Mock delete results
+    mock_result_chunks = MagicMock()
+    mock_result_doc = MagicMock()
+    mock_result_doc.rowcount = 0  # Not found or unauthorized
+
+    mock_session.execute.side_effect = [mock_result_chunks, mock_result_doc]
+
+    with patch("backend.storage.AsyncSessionLocal", return_value=mock_session_cm):
+        with pytest.raises(ValueError, match="Unauthorized or not found"):
+            await storage.db_delete_document("conv1", "doc1", "user1")
+
+    assert mock_session.rollback.called
+    assert not mock_session.commit.called


### PR DESCRIPTION
This PR optimizes the `db_delete_document` function in `backend/storage.py` by removing a redundant `select` query that was previously used for existence and authorization checks. 

### 💡 What:
Replaced the `select` -> `scalar_one_or_none` -> `session.delete(doc)` pattern with a direct SQLAlchemy `delete` statement. Authorization (`user_id` and `conversation_id`) is now enforced directly in the `delete` statement's `where` clause.

### 🎯 Why:
The previous implementation required an extra database roundtrip to fetch the document before deleting it. In environments with network latency (e.g., cloud-hosted databases), this extra roundtrip significantly increases the overall duration of the operation.

### 📊 Measured Improvement:
Using a mock benchmark with simulated 10ms database latency:
- **Baseline:** 0.0523s per operation.
- **Optimized:** 0.0385s per operation.
- **Improvement:** ~26.4% reduction in execution time.
- **Roundtrips saved:** 1.

The changes include:
- Optimized `db_delete_document` in `backend/storage.py`.
- A new benchmark script `scripts/benchmark_mock_delete.py` to quantify performance gains.
- A new test file `tests/verify_db_delete_optimization.py` to ensure correctness of the optimized logic.

---
*PR created automatically by Jules for task [14447355205288243425](https://jules.google.com/task/14447355205288243425) started by @ashwathravi*