### PR TITLE
🧪 Add unit tests for document processing helpers

### DIFF
--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -5,6 +5,34 @@ import pytest
 from backend import documents, retrieval, storage, config
 
 
+@pytest.mark.parametrize("text,expected", [
+    ("hello world", "hello world"),
+    ("hello   world", "hello world"),
+    ("hello\tworld", "hello world"),
+    ("hello\nworld", "hello world"),
+    ("  hello \n \t world  ", "hello world"),
+    ("", ""),
+    ("   \n\t  ", ""),
+    ("multiple   spaces   between   words", "multiple spaces between words"),
+])
+def test_normalize_text(text, expected):
+    assert documents.normalize_text(text) == expected
+
+
+@pytest.mark.parametrize("header,expected", [
+    (b"%PDF-1.4", True),
+    (b"%PDF-1.7", True),
+    (b"%PDF-2.0", True),
+    (b"PDF-1.4", False),
+    (b" %PDF-1.4", False),
+    (b"something %PDF-1.4", False),
+    (b"", False),
+    (b"random bytes", False),
+])
+def test_validate_pdf_header(header, expected):
+    assert documents.validate_pdf_header(header) == expected
+
+
 def test_chunk_pages_overlap():
     text = "one two three four five six seven eight nine ten"
     chunks = documents.chunk_pages([text], chunk_words=4, overlap_words=1)


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
I added unit tests for `normalize_text` and `validate_pdf_header` in `backend/documents.py`. These were pure functions that were previously untested.

### 📊 Coverage: What scenarios are now tested
- **`normalize_text`**:
    - Standard strings.
    - Multiple consecutive spaces, tabs, and newlines (all consolidated to a single space).
    - Leading and trailing whitespace (trimmed).
    - Empty strings and strings containing only whitespace.
- **`validate_pdf_header`**:
    - Various valid PDF version headers (`%PDF-1.4`, `%PDF-1.7`, `%PDF-2.0`).
    - Invalid headers (missing `%`, leading spaces, random text).
    - Empty byte strings.

### ✨ Result: The improvement in test coverage
Increased the reliability of the PDF processing pipeline by ensuring the core text normalization and file validation logic behaves as expected across all common edge cases.

---
*PR created automatically by Jules for task [18107879515593737031](https://jules.google.com/task/18107879515593737031) started by @ashwathravi*