### PR TITLE
🧹 Remove commented out code in frontend/src/App.jsx

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, lazy, Suspense, useMemo } from 'react';
-// import Sidebar from './components/Sidebar';
 import CouncilSidebar from './components/CouncilSidebar';
 import ChatInterface from './components/ChatInterface';
 import { api } from './api';
@@ -10,7 +9,6 @@ import { Moon, Sun, Menu, LogOut } from "lucide-react";
 
 const Login = lazy(() => import('./components/Login'));
 import { useAuth } from './contexts/AuthContextDefinition';
-// import './App.css'; // Deprecated
 
 function App() {
   const { user, isLoading: authLoading, logout } = useAuth();


### PR DESCRIPTION
Removed commented out imports for `Sidebar` and `App.css` in `frontend/src/App.jsx` to clean up dead code and improve maintainability. Verified with linting and existing tests.

---
*PR created automatically by Jules for task [17732070297976336511](https://jules.google.com/task/17732070297976336511) started by @ashwathravi*