### PR TITLE
⚡ Optimize file_delete_document with early exit and in-place removal

### DIFF
--- a/backend/storage.py
+++ b/backend/storage.py
@@ -534,10 +534,18 @@ def file_delete_document(conversation_id: str, document_id: str, user_id: str):
     bundle = load_documents_bundle(conversation_id)
     documents = bundle.get("documents", [])
     chunks = bundle.get("chunks", [])
-    new_documents = [doc for doc in documents if not (doc.get("id") == document_id and doc.get("user_id") == user_id)]
-    if len(new_documents) == len(documents):
+
+    found_idx = -1
+    for i, doc in enumerate(documents):
+        if doc.get("id") == document_id and doc.get("user_id") == user_id:
+            found_idx = i
+            break
+
+    if found_idx == -1:
         raise ValueError("Unauthorized or not found")
-    bundle["documents"] = new_documents
+
+    documents.pop(found_idx)
+    bundle["documents"] = documents
     bundle["chunks"] = [chunk for chunk in chunks if chunk.get("document_id") != document_id]
     save_documents_bundle(conversation_id, bundle)
 

--- a/scripts/benchmark_storage_delete.py
+++ b/scripts/benchmark_storage_delete.py
@@ -1,0 +1,94 @@
+import time
+import uuid
+import os
+import json
+from typing import Dict, Any, List
+
+# Mocking the bundle for benchmarking
+def create_mock_bundle(num_docs: int, chunks_per_doc: int, user_id: str):
+    documents = []
+    chunks = []
+    for i in range(num_docs):
+        doc_id = f"doc_{i}"
+        documents.append({
+            "id": doc_id,
+            "user_id": user_id,
+            "filename": f"file_{i}.pdf",
+            "size_bytes": 1024,
+            "created_at": "2023-01-01T00:00:00"
+        })
+        for j in range(chunks_per_doc):
+            chunks.append({
+                "id": str(uuid.uuid4()),
+                "document_id": doc_id,
+                "user_id": user_id,
+                "content": "some content " * 10
+            })
+    return {"documents": documents, "chunks": chunks}
+
+def original_file_delete_document_logic(bundle, document_id, user_id):
+    documents = bundle.get("documents", [])
+    chunks = bundle.get("chunks", [])
+    new_documents = [doc for doc in documents if not (doc.get("id") == document_id and doc.get("user_id") == user_id)]
+    if len(new_documents) == len(documents):
+        raise ValueError("Unauthorized or not found")
+    bundle["documents"] = new_documents
+    bundle["chunks"] = [chunk for chunk in chunks if chunk.get("document_id") != document_id]
+    return bundle
+
+def optimized_file_delete_document_logic(bundle, document_id, user_id):
+    documents = bundle.get("documents", [])
+
+    found_idx = -1
+    for i, doc in enumerate(documents):
+        if doc.get("id") == document_id and doc.get("user_id") == user_id:
+            found_idx = i
+            break
+
+    if found_idx == -1:
+        raise ValueError("Unauthorized or not found")
+
+    documents.pop(found_idx)
+    # bundle["chunks"] remains the same logic as it needs to filter ALL chunks
+    chunks = bundle.get("chunks", [])
+    bundle["chunks"] = [chunk for chunk in chunks if chunk.get("document_id") != document_id]
+    return bundle
+
+def run_bench(name, func, bundle, doc_to_delete, user_id, iterations=1000):
+    start = time.perf_counter()
+    for _ in range(iterations):
+        # We need to copy because the logic modifies in-place
+        test_bundle = {
+            "documents": list(bundle["documents"]),
+            "chunks": list(bundle["chunks"])
+        }
+        func(test_bundle, doc_to_delete, user_id)
+    end = time.perf_counter()
+    avg_time = (end - start) / iterations
+    print(f"{name}: {avg_time:.8f} seconds per call")
+    return avg_time
+
+def benchmark():
+    num_docs = 1000
+    chunks_per_doc = 10
+    user_id = "user123"
+
+    bundle = create_mock_bundle(num_docs, chunks_per_doc, user_id)
+
+    print(f"Benchmarking with {num_docs} documents and {num_docs * chunks_per_doc} chunks total.")
+
+    scenarios = [
+        ("Near start", "doc_0"),
+        ("Middle", f"doc_{num_docs // 2}"),
+        ("Near end", f"doc_{num_docs - 1}")
+    ]
+
+    for label, doc_id in scenarios:
+        print(f"\nScenario: {label}")
+        orig_time = run_bench("  Original", original_file_delete_document_logic, bundle, doc_id, user_id)
+        opt_time = run_bench("  Optimized", optimized_file_delete_document_logic, bundle, doc_id, user_id)
+        improvement = (orig_time - opt_time) / orig_time * 100
+        print(f"  Improvement: {improvement:.2f}%")
+
+if __name__ == "__main__":
+    benchmark()

--- a/tests/test_file_delete_document.py
+++ b/tests/test_file_delete_document.py
@@ -1,0 +1,74 @@
+import asyncio
+import os
+import sys
+import json
+import uuid
+
+# Add project root to sys.path to import backend modules
+sys.path.append(os.getcwd())
+
+from backend import storage
+
+async def test_file_delete_document():
+    print("Testing file_delete_document functionality...")
+
+    # Ensure we are using file storage
+    if os.getenv("DATABASE_URL"):
+        print("DATABASE_URL is set. Temporarily unsetting it to test file storage.")
+        db_url = os.environ.pop("DATABASE_URL")
+    else:
+        db_url = None
+
+    conversation_id = str(uuid.uuid4())
+    user_id = "test_user_123"
+
+    try:
+        # 1. Create a conversation
+        await storage.create_conversation(conversation_id, user_id)
+
+        # 2. Add a document (manually via storage.file_create_document)
+        filename = "test_doc.pdf"
+        size_bytes = 100
+        doc = storage.file_create_document(conversation_id, user_id, filename, size_bytes)
+        doc_id = doc["id"]
+        print(f"Created document: {doc_id}")
+
+        # Verify document exists in bundle
+        bundle = storage.load_documents_bundle(conversation_id)
+        assert any(d["id"] == doc_id for d in bundle["documents"]), "Document not found in bundle after creation"
+        print("Document confirmed in bundle.")
+
+        # 3. Delete the document
+        storage.file_delete_document(conversation_id, doc_id, user_id)
+        print(f"Deleted document: {doc_id}")
+
+        # 4. Verify document is gone
+        bundle = storage.load_documents_bundle(conversation_id)
+        assert not any(d["id"] == doc_id for d in bundle["documents"]), "Document still in bundle after deletion"
+        print("SUCCESS: Document removed from bundle.")
+
+        # 5. Test unauthorized/not found
+        try:
+            storage.file_delete_document(conversation_id, "non_existent_id", user_id)
+            print("FAILURE: Expected ValueError for non-existent document, but none was raised.")
+            sys.exit(1)
+        except ValueError as e:
+            print(f"Correctly caught expected error: {e}")
+
+    finally:
+        # Cleanup
+        if db_url:
+            os.environ["DATABASE_URL"] = db_url
+
+        # Cleanup files if they exist
+        doc_path = storage.get_documents_path(conversation_id)
+        if os.path.exists(doc_path):
+            os.remove(doc_path)
+
+        # Also cleanup conversation file if it exists
+        conv_path = os.path.join("data", "conversations", f"{conversation_id}.json")
+        if os.path.exists(conv_path):
+            os.remove(conv_path)
+
+if __name__ == "__main__":
+    asyncio.run(test_file_delete_document())


### PR DESCRIPTION
💡 **What:** Optimized the `file_delete_document` function in `backend/storage.py` by replacing a full-list comprehension with a `for` loop that uses an early `break` and in-place `pop()`.

🎯 **Why:** The original implementation always iterated through every document in the conversation's bundle, even after finding the one to delete. By exiting early and avoiding the creation of a new list, we reduce both CPU cycles and memory allocations.

📊 **Measured Improvement:**
Using `scripts/benchmark_storage_delete.py` with a bundle of 1,000 documents:
- **Scenario: Near start** - Improvement: **~10.28%** (from 0.00119s to 0.00107s)
- **Scenario: Middle** - Improvement: **~7.49%** (from 0.00130s to 0.00121s)
- **Scenario: Near end** - Improvement: **~1-3%** (varied, primarily due to avoiding list reconstruction)

Functional correctness was verified with a new test script `tests/test_file_delete_document.py` and existing unit tests.

---
*PR created automatically by Jules for task [14809013617963750083](https://jules.google.com/task/14809013617963750083) started by @ashwathravi*