### PR TITLE
Fix Exception Information Leak in /api/models and Backend Logs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ import os
 import io
 import time
 import requests
+import logging
 from contextlib import asynccontextmanager
 
 from . import storage, auth, openrouter, security, documents, retrieval, config
@@ -25,6 +26,8 @@ from .council import (
     stage3_synthesize_final, calculate_aggregate_rankings, resolve_active_models
 )
 from . import export
+
+logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -250,8 +253,8 @@ async def delete_conversation(conversation_id: str, user_id: str = Depends(auth.
         return {"status": "success"}
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        print(f"Error deleting conversation: {e}")
+    except Exception:
+        logger.error("Error deleting conversation", exc_info=False)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -261,8 +264,8 @@ async def list_models(user_id: str = Depends(auth.get_current_user_id)):
     try:
         models = await openrouter.fetch_models()
         return models
-    except Exception as e:
-        print(f"Error fetching models: {e}")
+    except Exception:
+        logger.error("Error fetching models", exc_info=False)
         # Security: Do not leak internal error details to client
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -1039,10 +1042,8 @@ async def send_message_stream(
                 f"responded={responded_council_models}"
             )
 
-        except Exception as e:
-            import traceback
-            traceback.print_exc()
-            print(f"Streaming error: {e}")
+        except Exception:
+            logger.error("Streaming error", exc_info=False)
             # Security: Do not leak internal error details to client
             yield f"data: {json.dumps({'type': 'error', 'error': 'An internal error occurred.'})}\n\n"
 

--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -117,11 +117,12 @@ async def fetch_models() -> List[Dict[str, Any]]:
             
     except httpx.HTTPStatusError as e:
         message = _extract_error_message(e.response)
+        logger.error("OpenRouter error %s: %s", e.response.status_code, message)
         raise RuntimeError(
             f"OpenRouter error {e.response.status_code}: {message}"
         ) from e
     except Exception as e:
-        print(f"Error fetching models: {e}")
+        logger.error("Error fetching models", exc_info=False)
         raise e
 
 async def query_model(
@@ -246,7 +247,7 @@ async def query_model(
             "status_code": e.response.status_code,
         }
     except Exception as e:
-        logger.exception("Error querying model %s", model)
+        logger.error("Error querying model %s", model, exc_info=False)
         return {
             "content": None,
             "reasoning_details": None,
@@ -361,5 +362,5 @@ async def query_model_stream(
                 logger.warning("OpenRouter stream for %s closed without [DONE] marker.", model)
 
     except Exception as e:
-        logger.exception("Error querying model stream %s", model)
-        raise RuntimeError(f"Streaming failed for model {model}: {e}") from e
+        logger.error("Error querying model stream %s", model, exc_info=False)
+        raise RuntimeError(f"Streaming failed for model {model}") from e

--- a/backend/retrieval.py
+++ b/backend/retrieval.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import numpy as np
+import logging
 from typing import List, Dict, Any, Tuple
 from starlette.concurrency import run_in_threadpool
 
 from . import storage, documents
 from .config import RETRIEVAL_TOP_K, RETRIEVAL_MAX_TOTAL_CHARS, RETRIEVAL_MAX_CHARS_PER_CHUNK
 
+logger = logging.getLogger(__name__)
 
 def _build_context(citations: List[Dict[str, Any]]) -> str:
     if not citations:
@@ -110,8 +112,6 @@ async def build_retrieval_context(
 
         context = _build_context(citations)
         return (context if context else None), citations
-    except Exception as e:
-        import traceback
-        traceback.print_exc()
-        print(f"Retrieval error: {e}")
+    except Exception:
+        logger.error("Retrieval error", exc_info=False)
         return None, []


### PR DESCRIPTION
I have addressed the security concern where sensitive information (like database connection strings) was being leaked through the `/api/models` endpoint. Although the API response was already returning a generic 500 error, the server-side logs were still printing raw exceptions that could contain sensitive data.

I updated `backend/main.py`, `backend/openrouter.py`, and `backend/retrieval.py` to:
1.  Replace all `print` and `traceback.print_exc` statements with the standard `logging` framework.
2.  Use `logger.error(..., exc_info=False)` in catch blocks for sensitive operations to ensure that while the error is logged, the full exception object (and any sensitive data it contains) is not printed to the logs.
3.  Sanitize any error messages that might include raw exception details.

I verified these changes by:
-   Running the existing security tests in `tests/test_error_handling_security.py` (which pass).
-   Creating a `verify_leak.py` script to manually trigger errors and confirm that neither the API response nor the console logs contained the sensitive information.
-   Requesting a code review and refining the logging strategy to ensure both security and debuggability.


---
*PR created automatically by Jules for task [6935362843976886749](https://jules.google.com/task/6935362843976886749) started by @ashwathravi*