### PR TITLE
🔒 Enforce SSL certificate verification for database connections

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -99,14 +99,24 @@ def configure_ssl_context(query_params: dict):
             ssl_context.verify_mode = ssl.CERT_REQUIRED
             connect_args["ssl"] = ssl_context
 
-        # Require: Encryption required, but verification optional (Legacy/Compat)
+        # Require: Encryption required, and now verification is enforced for security.
         elif ssl_mode == "require":
-            # Create a custom SSL context to avoid certificate verification errors
-            # which are common in some deployment environments (e.g. Render, self-signed)
             ssl_context = ssl.create_default_context()
             ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
             connect_args["ssl"] = ssl_context
+
+    # Support for custom CA bundle
+    if "sslrootcert" in query_params:
+        root_cert = query_params.pop("sslrootcert")
+        # Ensure we have an SSL context if sslrootcert is provided
+        if "ssl" not in connect_args:
+            ssl_context = ssl.create_default_context()
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            connect_args["ssl"] = ssl_context
+
+        connect_args["ssl"].load_verify_locations(cafile=root_cert)
 
     return connect_args, query_params
 

--- a/tests/test_db_ssl.py
+++ b/tests/test_db_ssl.py
@@ -31,17 +31,39 @@ def test_verify_ca_is_secure_cert_only():
     assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is False
 
-def test_require_is_still_lenient():
+def test_require_is_now_secure():
     """
-    Asserts that sslmode=require remains lenient (CERT_NONE) for compatibility.
+    Asserts that sslmode=require now enforces certificate validation.
     """
     query_params = {"sslmode": "require"}
     connect_args, updated_params = configure_ssl_context(query_params)
 
     ctx = connect_args.get("ssl")
     assert ctx is not None
-    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is False
+
+def test_sslrootcert_is_processed(tmp_path):
+    """
+    Asserts that sslrootcert is correctly processed and loaded into the SSL context.
+    """
+    # Create a dummy root cert file
+    cert_file = tmp_path / "root.crt"
+    cert_file.write_text("dummy certificate content")
+
+    query_params = {"sslmode": "require", "sslrootcert": str(cert_file)}
+
+    # We need to mock load_verify_locations because it will fail with dummy content
+    import unittest.mock as mock
+    with mock.patch("ssl.SSLContext.load_verify_locations") as mock_load:
+        connect_args, updated_params = configure_ssl_context(query_params)
+
+        ctx = connect_args.get("ssl")
+        assert ctx is not None
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        mock_load.assert_called_once_with(cafile=str(cert_file))
+
+    assert "sslrootcert" not in updated_params
 
 def test_no_sslmode():
     """


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This fix addresses an insecure SSL configuration in `backend/database.py` where `sslmode=require` was explicitly disabling certificate verification.

⚠️ **Risk:** The potential impact if left unfixed
If left unfixed, database connections using `sslmode=require` would be encrypted but not authenticated. This makes the connection vulnerable to Man-in-the-Middle (MITM) attacks, where an attacker could intercept or modify data between the application and the database.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix changes the default behavior for `sslmode=require` to enforce certificate verification (`ssl.CERT_REQUIRED`). To maintain compatibility with environments using non-standard or self-signed certificates, support for the `sslrootcert` query parameter was added, allowing users to securely provide their own CA bundle for verification.

---
*PR created automatically by Jules for task [6679131774123036370](https://jules.google.com/task/6679131774123036370) started by @ashwathravi*