### PR TITLE
[codex] Add council weighting, conversation navigation, and backend hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Workflows
+
+### Local development
+- Install dependencies: `uv sync` and `cd frontend && npm install`
+- Bootstrap Codex environment: `./codex_setup.sh`
+- Bootstrap Jules environment: `./jules_setup.sh`
+- Run both services: `./start.sh`
+- Run backend only: `uv run python -m backend.main`
+- Run frontend only: `cd frontend && npm run dev`
+
+### Validation
+- Run backend tests: `uv run pytest`
+- Lint frontend: `cd frontend && npm run lint`
+- Build frontend: `cd frontend && npm run build`
+- Preview production frontend build: `cd frontend && npm run preview`
+
+### Utility scripts
+- Export benchmark script: `python scripts/benchmark_export.py`
+- Retrieval benchmark script: `python scripts/measure_retrieval.py`
+- Add DB index migration: `uv run python scripts/add_index.py`
+- Scout assigned GitHub issues into `.agent/passports`: `gh auth login && ./scripts/scout_agent.py`
+
+### Agentic workflow bootstrap
+- Create a new feature passport: `cp .agent/templates/feature_passport.md .agent/passports/my_feature.md`
+
+### Container workflow
+- Build and run with Docker Compose: `docker compose up --build`
+
+## TODO
+- Confirm whether utility scripts should be run via `uv run python ...` for environment consistency.

--- a/Info/architecture.md
+++ b/Info/architecture.md
@@ -1,0 +1,34 @@
+# Architecture
+
+- Two-part application:
+  - FastAPI backend in `backend/`
+  - React 19 + Vite SPA in `frontend/`
+- Backend owns all state and orchestration:
+  - conversations
+  - uploaded documents
+  - retrieval
+  - council execution
+  - auth/session validation
+- Primary persistence is Postgres via SQLAlchemy async models:
+  - `conversations`
+  - `documents`
+  - `document_chunks`
+- Conversation and message bodies are stored as JSON columns, not normalized message tables.
+- If `DATABASE_URL` is absent, storage falls back to JSON files under `data/conversations` and `data/documents`.
+- PDF ingestion pipeline:
+  - validate file type and magic header
+  - extract text with `pypdf`
+  - chunk by words with overlap
+  - embed chunks with `sentence-transformers/all-MiniLM-L6-v2`
+  - store chunks plus embeddings for retrieval.
+- Retrieval is embedding-based:
+  - embed user query
+  - score saved chunk embeddings with numpy dot product
+  - fetch top chunk texts
+  - prepend a system retrieval block to model prompts.
+- Council execution is a 3-stage pipeline:
+  - Stage 1: collect per-model responses
+  - Stage 2: rank or critique those responses depending on framework
+  - Stage 3: chairman model synthesizes the final answer
+- The streaming endpoint emits SSE events for stage starts, incremental Stage 1 updates, Stage 3 tokens, completion, and errors.
+- In production the backend also serves the built frontend from `frontend/dist`.

--- a/Info/current-focus.md
+++ b/Info/current-focus.md
@@ -1,0 +1,13 @@
+# Current Focus
+
+- Core implemented path is:
+  - create conversation
+  - send prompt
+  - run council pipeline
+  - stream updates to the UI
+  - persist the finished assistant turn.
+- Document upload, chunking, embedding, and retrieval are implemented and integrated into both sync and streaming council runs.
+- Retry support exists for failed Stage 1 model calls, with optional rerun of later stages.
+- Export exists for Markdown and PDF conversation downloads.
+- Frontend work is centered on the chat workspace, council configuration, conversation navigation, and stage-by-stage rendering.
+- The real backend auth flow exists, but the current frontend auth provider initializes with a hard-coded test user before login, so the UI does not strictly enforce real authentication state on first load.

--- a/Info/decisions.md
+++ b/Info/decisions.md
@@ -1,0 +1,17 @@
+# Decisions
+
+- Keep the frontend thin and push orchestration, retrieval, storage, and export logic into the backend.
+- Use OpenRouter as the model gateway and treat council/chairman models as runtime-configurable conversation settings.
+- Store whole conversations as JSON blobs instead of a relational message schema.
+- Support both database and filesystem storage so the app can run with or without Postgres.
+- Reuse one shared `httpx.AsyncClient` for OpenRouter traffic.
+- Run expensive work off the event loop where needed:
+  - PDF parsing in a threadpool
+  - embedding inference in a threadpool.
+- Use SSE for chat so the UI can render stage-by-stage progress and token streaming.
+- Require Google login + backend-issued JWT for API access, with optional email/domain allowlists.
+- Add basic hardening in-process:
+  - CORS allowlist
+  - security headers
+  - in-memory per-IP rate limiting.
+- Build frontend separately and ship a single backend container that serves both API and SPA assets.

--- a/Info/open-questions.md
+++ b/Info/open-questions.md
@@ -1,0 +1,8 @@
+# Open Questions
+
+- Is Postgres the intended production default, or is filesystem mode still a supported long-term deployment mode?
+- Is storing full message history as one JSON column per conversation acceptable as conversations grow, or should messages move to a separate table?
+- Should the frontend auth provider keep the current hard-coded test user bootstrap, or be aligned with the JWT-backed backend flow?
+- Are OpenRouter model discovery and the `"tools"` filter still the intended way to populate selectable council models?
+- How large can document corpora grow before in-process embedding retrieval and JSON-stored embeddings become a bottleneck?
+- Should rate limiting remain in-memory per process, or move to a shared store for multi-instance deployments?

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,7 +1,6 @@
 """Authentication module for Google Sign-In and JWT management."""
 
 import os
-import sys
 import jwt
 import logging
 from typing import Dict, Any, Optional
@@ -10,7 +9,6 @@ from google.oauth2 import id_token
 from google.auth.transport import requests
 from fastapi import HTTPException, status, Header, Depends
 from pydantic import BaseModel
-from .config import APP_ORIGIN
 from . import config
 
 # Setup logging
@@ -23,21 +21,11 @@ jwt_secret = os.getenv("JWT_SECRET_KEY")
 if jwt_secret:
     SECRET_KEY = jwt_secret
 else:
-    if APP_ORIGIN == "local":
-        SECRET_KEY = "dev_secret_key_change_in_production"
-        # Log warning (and print to stderr to ensure visibility during startup)
-        logger.warning("JWT_SECRET_KEY is not set. Using insecure default key.")
-        print(
-            "WARNING: JWT_SECRET_KEY is not set. Using insecure default key. "
-            "This is unsafe for production!",
-            file=sys.stderr
-        )
-    else:
-        # In production (Render, Replit, etc.), fail fast if no secret is set
-        raise RuntimeError(
-            f"CRITICAL SECURITY ERROR: JWT_SECRET_KEY is missing in {APP_ORIGIN} environment. "
-            "You must set a secure random string for JWT_SECRET_KEY to start the application."
-        )
+    # Fail fast if no secret is set across all environments
+    raise RuntimeError(
+        "CRITICAL SECURITY ERROR: JWT_SECRET_KEY is missing. "
+        "You must set a secure random string for JWT_SECRET_KEY to start the application."
+    )
 
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days

--- a/backend/council.py
+++ b/backend/council.py
@@ -1,5 +1,6 @@
 """3-stage LLM Council orchestration."""
 
+import re
 from typing import List, Dict, Any, Tuple, Optional
 from .openrouter import query_models_parallel, query_model, query_model_stream
 from .config import (
@@ -12,6 +13,10 @@ from .config import (
     FAST_LOCAL_TITLE,
     TITLE_MODEL,
 )
+
+# Pre-compiled regex patterns for parsing model rankings
+NUMBERED_RESPONSE_RE = re.compile(r'\d+\.\s*Response [A-Z]', re.IGNORECASE)
+RESPONSE_LABEL_RE = re.compile(r'Response\s+([A-Z])', re.IGNORECASE)
 
 
 def _apply_retrieval_context(messages: List[Dict[str, str]], retrieval_context: Optional[str]) -> List[Dict[str, str]]:
@@ -178,8 +183,6 @@ def parse_ranking_from_text(ranking_text: str) -> List[str]:
     Returns:
         List of response labels in ranked order
     """
-    import re
-
     # Look for "FINAL RANKING:" section (case-insensitive)
     marker = "FINAL RANKING:"
     upper_text = ranking_text.upper()
@@ -190,22 +193,22 @@ def parse_ranking_from_text(ranking_text: str) -> List[str]:
         ranking_section = ranking_text[marker_idx + len(marker):]
         # Try to extract numbered list format (e.g., "1. Response A")
         # This pattern looks for: number, period, optional space, "Response X"
-        numbered_matches = re.findall(r'\d+\.\s*Response [A-Z]', ranking_section, re.IGNORECASE)
+        numbered_matches = NUMBERED_RESPONSE_RE.findall(ranking_section)
         if numbered_matches:
             # Extract and normalize the "Response X" part
             results = []
             for m in numbered_matches:
-                inner = re.search(r'Response\s+([A-Z])', m, re.IGNORECASE)
+                inner = RESPONSE_LABEL_RE.search(m)
                 if inner:
                     results.append(f"Response {inner.group(1).upper()}")
             return results
 
         # Fallback: Extract all "Response X" patterns in order from the section
-        matches = re.findall(r'Response\s+([A-Z])', ranking_section, re.IGNORECASE)
+        matches = RESPONSE_LABEL_RE.findall(ranking_section)
         return [f"Response {m.upper()}" for m in matches]
 
     # Fallback: try to find any "Response X" patterns in order in full text
-    matches = re.findall(r'Response\s+([A-Z])', ranking_text, re.IGNORECASE)
+    matches = RESPONSE_LABEL_RE.findall(ranking_text)
     return [f"Response {m.upper()}" for m in matches]
 
 

--- a/backend/council.py
+++ b/backend/council.py
@@ -1,5 +1,6 @@
 """3-stage LLM Council orchestration."""
 
+from collections import defaultdict
 import re
 from typing import List, Dict, Any, Tuple, Optional
 from .openrouter import query_models_parallel, query_model, query_model_stream
@@ -17,6 +18,11 @@ from .config import (
 # Pre-compiled regex patterns for parsing model rankings
 NUMBERED_RESPONSE_RE = re.compile(r'\d+\.\s*Response [A-Z]', re.IGNORECASE)
 RESPONSE_LABEL_RE = re.compile(r'Response\s+([A-Z])', re.IGNORECASE)
+CONFIDENCE_RE = re.compile(r'^\s*CONFIDENCE\s*:\s*(\d{1,3})\s*$', re.IGNORECASE | re.MULTILINE)
+
+DEFAULT_CONFIDENCE_SCORE = 50
+DEFAULT_MODEL_PERFORMANCE = 0.5
+MIN_CONFIDENCE_WEIGHT = 0.25
 
 
 def _apply_retrieval_context(messages: List[Dict[str, str]], retrieval_context: Optional[str]) -> List[Dict[str, str]]:
@@ -30,9 +36,165 @@ def _limit_models(models: List[str]) -> List[str]:
         return models
     return models[:MAX_MODELS_PER_REQUEST]
 
+
 def resolve_active_models(council_models: Optional[List[str]] = None) -> List[str]:
     selected_models = council_models if council_models and len(council_models) > 0 else COUNCIL_MODELS
     return _limit_models(selected_models)
+
+
+def parse_confidence_from_text(response_text: str) -> Optional[int]:
+    """Parse a trailing CONFIDENCE line from a model ranking response."""
+    if not response_text:
+        return None
+
+    match = CONFIDENCE_RE.search(response_text)
+    if not match:
+        return None
+
+    value = int(match.group(1))
+    return max(0, min(100, value))
+
+
+def _normalize_confidence_score(confidence_score: Optional[int]) -> int:
+    if confidence_score is None:
+        return DEFAULT_CONFIDENCE_SCORE
+    return max(0, min(100, int(confidence_score)))
+
+
+def _confidence_to_weight(confidence_score: Optional[int]) -> float:
+    normalized = _normalize_confidence_score(confidence_score) / 100
+    return round(max(MIN_CONFIDENCE_WEIGHT, normalized), 3)
+
+
+def _default_model_profile(model_name: str) -> Dict[str, Any]:
+    return {
+        "model": model_name,
+        "rounds_observed": 0,
+        "average_performance": DEFAULT_MODEL_PERFORMANCE,
+        "dynamic_weight": 1.0,
+        "last_average_rank": None,
+    }
+
+
+def _normalize_rank_to_performance(rank_value: float, participant_count: int) -> float:
+    if participant_count <= 1:
+        return 1.0
+    normalized = 1 - ((rank_value - 1) / (participant_count - 1))
+    return max(0.0, min(1.0, normalized))
+
+
+def _coerce_average_rank(rank_entry: Dict[str, Any], participant_count: int) -> float:
+    if not isinstance(rank_entry, dict):
+        return float(participant_count)
+
+    raw_value = rank_entry.get("average_rank")
+    if isinstance(raw_value, (int, float)):
+        return float(raw_value)
+    return float(participant_count)
+
+
+def apply_round_to_model_profiles(
+    model_profiles: Optional[Dict[str, Dict[str, Any]]],
+    aggregate_rankings: List[Dict[str, Any]],
+    responded_models: List[str]
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Update model profiles using a single completed ranking round.
+
+    The repo does not yet have a gold-answer benchmark pipeline, so the rolling
+    performance signal is derived from prior council rankings within the same
+    conversation.
+    """
+    updated_profiles: Dict[str, Dict[str, Any]] = {
+        model: dict(profile)
+        for model, profile in (model_profiles or {}).items()
+    }
+
+    if not responded_models:
+        return updated_profiles
+
+    ranking_by_model = {
+        entry.get("model"): entry
+        for entry in aggregate_rankings
+        if isinstance(entry, dict) and isinstance(entry.get("model"), str)
+    }
+    participant_count = len(responded_models)
+
+    for model_name in responded_models:
+        profile = updated_profiles.get(model_name, _default_model_profile(model_name))
+        rank_value = _coerce_average_rank(ranking_by_model.get(model_name), participant_count)
+        performance = _normalize_rank_to_performance(rank_value, participant_count)
+        prior_rounds = int(profile.get("rounds_observed", 0) or 0)
+        prior_average = float(profile.get("average_performance", DEFAULT_MODEL_PERFORMANCE))
+        next_average = (
+            ((prior_average * prior_rounds) + performance) / (prior_rounds + 1)
+            if prior_rounds > 0 else performance
+        )
+        profile.update({
+            "model": model_name,
+            "rounds_observed": prior_rounds + 1,
+            "average_performance": round(next_average, 3),
+            "dynamic_weight": round(0.5 + next_average, 3),
+            "last_average_rank": round(rank_value, 2),
+        })
+        updated_profiles[model_name] = profile
+
+    return updated_profiles
+
+
+def build_model_weight_profile(
+    conversation_messages: Optional[List[Dict[str, Any]]],
+    active_models: Optional[List[str]] = None
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Build rolling model profiles from prior assistant messages in a conversation.
+    """
+    profiles: Dict[str, Dict[str, Any]] = {}
+    for model_name in active_models or []:
+        profiles[model_name] = _default_model_profile(model_name)
+
+    for message in conversation_messages or []:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+
+        metadata = message.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+
+        aggregate_rankings = metadata.get("aggregate_rankings")
+        if not isinstance(aggregate_rankings, list) or not aggregate_rankings:
+            continue
+
+        responded_models = metadata.get("responded_council_models")
+        if not isinstance(responded_models, list) or not responded_models:
+            responded_models = [
+                entry.get("model")
+                for entry in aggregate_rankings
+                if isinstance(entry, dict) and isinstance(entry.get("model"), str)
+            ]
+
+        profiles = apply_round_to_model_profiles(profiles, aggregate_rankings, responded_models)
+
+    return profiles
+
+
+def serialize_model_weight_profile(
+    model_profiles: Optional[Dict[str, Dict[str, Any]]],
+    model_order: Optional[List[str]] = None
+) -> List[Dict[str, Any]]:
+    if not model_profiles:
+        return []
+
+    ordered_models = list(model_order or [])
+    for model_name in model_profiles.keys():
+        if model_name not in ordered_models:
+            ordered_models.append(model_name)
+
+    return [
+        dict(model_profiles[model_name], model=model_name)
+        for model_name in ordered_models
+        if model_name in model_profiles
+    ]
 
 
 def _fallback_title_from_query(user_query: str) -> str:
@@ -86,7 +248,9 @@ async def stage2_collect_rankings(
     stage1_results: List[Dict[str, Any]],
     council_models: List[str] = None,
     chairman_model: str = None,
-    retrieval_context: Optional[str] = None
+    retrieval_context: Optional[str] = None,
+    framework: str = "standard",
+    model_profiles: Optional[Dict[str, Dict[str, Any]]] = None
 ) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
     """
     Stage 2: Each model ranks the anonymized responses.
@@ -120,19 +284,26 @@ async def stage2_collect_rankings(
     if retrieval_context:
         retrieval_block = f"\n\nRelevant document excerpts:\n{retrieval_context}\n"
 
-    ranking_prompt = f"""You are evaluating different responses to the following question:
+    if framework == "heterogeneous":
+        ranking_instructions = """2. Then, at the very end of your response, provide a final ranking and a confidence score.
 
-Question: {user_query}
+IMPORTANT: Your final ranking MUST be formatted EXACTLY as follows:
+- Start with the line "FINAL RANKING:" (all caps, with colon)
+- Then list the responses from best to worst as a numbered list
+- Each line should be: number, period, space, then ONLY the response label (e.g., "1. Response A")
+- After the ranking, add one final line in the form "CONFIDENCE: 78"
+- Use an integer confidence score from 0 to 100 based on how confident you are in your ranking
+- Do not add any other text or explanations after the confidence line
 
-{retrieval_block}
+Example of the correct ending:
 
-Here are the responses from different models (anonymized):
-
-{responses_text}
-
-Your task:
-1. First, evaluate each response individually. For each response, explain what it does well and what it does poorly.
-2. Then, at the very end of your response, provide a final ranking.
+FINAL RANKING:
+1. Response C
+2. Response A
+3. Response B
+CONFIDENCE: 78"""
+    else:
+        ranking_instructions = """2. Then, at the very end of your response, provide a final ranking.
 
 IMPORTANT: Your final ranking MUST be formatted EXACTLY as follows:
 - Start with the line "FINAL RANKING:" (all caps, with colon)
@@ -149,7 +320,21 @@ Response C offers the most comprehensive answer...
 FINAL RANKING:
 1. Response C
 2. Response A
-3. Response B
+3. Response B"""
+
+    ranking_prompt = f"""You are evaluating different responses to the following question:
+
+Question: {user_query}
+
+{retrieval_block}
+
+Here are the responses from different models (anonymized):
+
+{responses_text}
+
+Your task:
+1. First, evaluate each response individually. For each response, explain what it does well and what it does poorly.
+{ranking_instructions}
 
 Now provide your evaluation and ranking:"""
 
@@ -164,11 +349,22 @@ Now provide your evaluation and ranking:"""
         if response is not None and not response.get("error"):
             full_text = response.get('content', '')
             parsed = parse_ranking_from_text(full_text)
-            stage2_results.append({
+            stage2_entry = {
                 "model": model,
                 "ranking": full_text,
                 "parsed_ranking": parsed
-            })
+            }
+            if framework == "heterogeneous":
+                confidence_score = _normalize_confidence_score(parse_confidence_from_text(full_text))
+                historical_weight = 1.0
+                if model_profiles and isinstance(model_profiles.get(model), dict):
+                    historical_weight = float(model_profiles[model].get("dynamic_weight", 1.0))
+                stage2_entry.update({
+                    "confidence_score": confidence_score,
+                    "historical_weight": round(historical_weight, 3),
+                    "ballot_weight": round(historical_weight * _confidence_to_weight(confidence_score), 3),
+                })
+            stage2_results.append(stage2_entry)
 
     return stage2_results, label_to_model
 
@@ -226,32 +422,47 @@ def calculate_aggregate_rankings(
     Returns:
         List of dicts with model name and average rank, sorted best to worst
     """
-    from collections import defaultdict
-
-    # Track positions for each model
     model_positions = defaultdict(list)
+    model_weighted_positions = defaultdict(list)
+    ballot_counts = defaultdict(int)
+    uses_weighted_ballots = False
 
     for ranking in stage2_results:
-        ranking_text = ranking['ranking']
-
-        # Parse the ranking from the structured format
-        parsed_ranking = parse_ranking_from_text(ranking_text)
+        ranking_text = ranking["ranking"]
+        parsed_ranking = ranking.get("parsed_ranking")
+        if not isinstance(parsed_ranking, list):
+            parsed_ranking = parse_ranking_from_text(ranking_text)
+        ballot_weight = ranking.get("ballot_weight", 1.0)
+        if not isinstance(ballot_weight, (int, float)):
+            ballot_weight = 1.0
+        ballot_weight = float(ballot_weight)
+        if abs(ballot_weight - 1.0) > 1e-9:
+            uses_weighted_ballots = True
 
         for position, label in enumerate(parsed_ranking, start=1):
             if label in label_to_model:
                 model_name = label_to_model[label]
                 model_positions[model_name].append(position)
+                model_weighted_positions[model_name].append((position, ballot_weight))
+                ballot_counts[model_name] += 1
 
     # Calculate average position for each model
     aggregate = []
     for model, positions in model_positions.items():
         if positions:
-            avg_rank = sum(positions) / len(positions)
-            aggregate.append({
+            weighted_positions = model_weighted_positions[model]
+            total_weight = sum(weight for _, weight in weighted_positions) or float(len(positions))
+            weighted_sum = sum(position * weight for position, weight in weighted_positions)
+            avg_rank = weighted_sum / total_weight if total_weight else (sum(positions) / len(positions))
+            entry = {
                 "model": model,
                 "average_rank": round(avg_rank, 2),
-                "rankings_count": len(positions)
-            })
+                "rankings_count": ballot_counts[model],
+            }
+            if uses_weighted_ballots:
+                entry["total_weight"] = round(total_weight, 3)
+                entry["weighted"] = True
+            aggregate.append(entry)
 
     # Sort by average rank (lower is better)
     aggregate.sort(key=lambda x: x['average_rank'])
@@ -306,7 +517,8 @@ async def run_full_council(
     council_models: list = None,
     chairman_model: str = None,
     retrieval_context: Optional[str] = None,
-    retrieval_citations: Optional[List[Dict[str, Any]]] = None
+    retrieval_citations: Optional[List[Dict[str, Any]]] = None,
+    conversation_messages: Optional[List[Dict[str, Any]]] = None
 ):
     """
     Orchestrates the selected council process.
@@ -319,6 +531,10 @@ async def run_full_council(
     requested_council_models = list(council_models) if council_models else []
     active_council_models = resolve_active_models(council_models)
     active_chairman_model = chairman_model if chairman_model else CHAIRMAN_MODEL
+    model_profiles = (
+        build_model_weight_profile(conversation_messages, active_council_models)
+        if framework == "heterogeneous" else {}
+    )
 
     # Stage 1: Collect responses
     # We need to pass the full messages to stage 1 functions
@@ -368,13 +584,26 @@ async def run_full_council(
             stage1_results,
             active_council_models,
             active_chairman_model,
-            retrieval_context=retrieval_context
+            retrieval_context=retrieval_context,
+            framework=framework,
+            model_profiles=model_profiles
         )
 
     # Calculate aggregate rankings if applicable
     aggregate_rankings = []
     if framework in ["standard", "six_hats"] and stage2_results:
         aggregate_rankings = calculate_aggregate_rankings(stage2_results, label_to_model)
+    elif framework == "heterogeneous" and stage2_results:
+        aggregate_rankings = calculate_aggregate_rankings(stage2_results, label_to_model)
+
+    updated_model_profiles = (
+        apply_round_to_model_profiles(
+            model_profiles,
+            aggregate_rankings,
+            [result["model"] for result in stage1_results]
+        )
+        if framework == "heterogeneous" and aggregate_rankings else model_profiles
+    )
 
     # Stage 3: Synthesize
     stage3_text = ""
@@ -384,7 +613,8 @@ async def run_full_council(
         stage2_results,
         active_chairman_model,
         mode=framework,
-        retrieval_context=retrieval_context
+        retrieval_context=retrieval_context,
+        aggregate_rankings=aggregate_rankings
     ):
         stage3_text += chunk
 
@@ -405,6 +635,16 @@ async def run_full_council(
         "stage1_errors": stage1_errors,
         "retrieval": {"citations": retrieval_citations or []},
     }
+    if framework == "heterogeneous":
+        metadata["model_weight_profile"] = serialize_model_weight_profile(
+            updated_model_profiles,
+            active_council_models
+        )
+        metadata["ballot_weighting"] = {
+            "mode": "confidence_x_rolling_performance",
+            "confidence_source": "stage2_self_report",
+            "history_source": "prior_conversation_rankings",
+        }
 
     return stage1_results, stage2_results, stage3_result, metadata
 
@@ -658,7 +898,8 @@ async def stage3_synthesize_final(
     stage2_results: List[Dict[str, Any]],
     chairman_model: str = None,
     mode: str = "standard",
-    retrieval_context: Optional[str] = None
+    retrieval_context: Optional[str] = None,
+    aggregate_rankings: Optional[List[Dict[str, Any]]] = None
 ):
     """
     Stage 3: Chairman synthesizes final response (streaming).
@@ -673,10 +914,19 @@ async def stage3_synthesize_final(
         for result in stage1_results
     ])
 
-    stage2_text = "\n\n".join([
-        f"Model: {result['model']}\nFeedback: {result['ranking']}"
-        for result in stage2_results
-    ])
+    stage2_entries = []
+    for result in stage2_results:
+        stage2_lines = [f"Model: {result['model']}"]
+        if mode == "heterogeneous":
+            if "confidence_score" in result:
+                stage2_lines.append(f"Confidence Score: {result['confidence_score']}")
+            if "historical_weight" in result:
+                stage2_lines.append(f"Historical Weight: {result['historical_weight']}")
+            if "ballot_weight" in result:
+                stage2_lines.append(f"Ballot Weight: {result['ballot_weight']}")
+        stage2_lines.append(f"Feedback: {result['ranking']}")
+        stage2_entries.append("\n".join(stage2_lines))
+    stage2_text = "\n\n".join(stage2_entries)
     
     if mode == "debate":
         instruction = "Synthesize a final answer by weighing the original arguments and the peer critiques. Resolve the conflicts and find the strongest truth."
@@ -688,6 +938,9 @@ async def stage3_synthesize_final(
         stage2_text = "(Stage 2 skipped for Ensemble mode)"
         instruction = "Synthesize the provided responses into a single, high-quality answer. Identify the consensus and best insights from the ensemble."
         stage2_label = "STAGE 2 - Skipped"
+    elif mode == "heterogeneous":
+        instruction = "Synthesize a final answer by prioritizing responses that earned the strongest weighted support from confident voters with stronger recent council performance."
+        stage2_label = "STAGE 2 - Weighted Peer Rankings:"
     else: # standard
         instruction = "Synthesize all of this information into a single, comprehensive, accurate answer. Consider the individual responses and the peer rankings."
         stage2_label = "STAGE 2 - Peer Rankings:"
@@ -695,6 +948,24 @@ async def stage3_synthesize_final(
     retrieval_block = ""
     if retrieval_context:
         retrieval_block = f"\nRETRIEVED DOCUMENT EXCERPTS:\n{retrieval_context}\n"
+
+    weighted_consensus_block = ""
+    if mode == "heterogeneous" and aggregate_rankings:
+        summary_lines = []
+        for entry in aggregate_rankings:
+            model_name = entry.get("model", "unknown")
+            average_rank = entry.get("average_rank")
+            rankings_count = entry.get("rankings_count")
+            total_weight = entry.get("total_weight")
+            if total_weight is not None:
+                summary_lines.append(
+                    f"- {model_name}: weighted average rank {average_rank} across {rankings_count} ballots (total weight {total_weight})"
+                )
+            else:
+                summary_lines.append(
+                    f"- {model_name}: average rank {average_rank} across {rankings_count} ballots"
+                )
+        weighted_consensus_block = "WEIGHTED CONSENSUS SUMMARY:\n" + "\n".join(summary_lines) + "\n"
 
     chairman_prompt = f"""You are the Chairman of an LLM Council.
     
@@ -706,6 +977,8 @@ STAGE 1 - Individual Responses:
 
 {stage2_label}
 {stage2_text}
+
+{weighted_consensus_block}
 
 Your task: {instruction}
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Any, Dict
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy import String, DateTime, JSON, text, Integer, Text, Index
+from sqlalchemy.engine.url import make_url
 from .config import DATABASE_URL
 
 # --- Database Setup ---
@@ -73,8 +74,6 @@ class DocumentChunkModel(Base):
 # Only create engine if DATABASE_URL is set
 engine = None
 AsyncSessionLocal = None
-
-from sqlalchemy.engine.url import make_url
 
 def configure_ssl_context(query_params: dict):
     """

--- a/backend/database.py
+++ b/backend/database.py
@@ -82,30 +82,35 @@ def configure_ssl_context(query_params: dict):
     Returns (connect_args_dict, updated_query_params).
     """
     connect_args = {}
+    ssl_root_cert = query_params.pop("sslrootcert", None)
+
     if "sslmode" in query_params:
         ssl_mode = query_params.pop("sslmode")
+        ssl_context = None
 
         # Verify-Full: Strict verification (Certificate + Hostname)
         if ssl_mode == "verify-full":
             ssl_context = ssl.create_default_context()
             ssl_context.check_hostname = True
             ssl_context.verify_mode = ssl.CERT_REQUIRED
-            connect_args["ssl"] = ssl_context
 
         # Verify-CA: Verify Certificate only (No hostname check)
         elif ssl_mode == "verify-ca":
             ssl_context = ssl.create_default_context()
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_REQUIRED
-            connect_args["ssl"] = ssl_context
 
         # Require: Encryption required, but verification optional (Legacy/Compat)
         elif ssl_mode == "require":
-            # Create a custom SSL context to avoid certificate verification errors
-            # which are common in some deployment environments (e.g. Render, self-signed)
+            # Encryption with certificate verification to prevent MITM.
+            # Hostname check is disabled for compatibility with some cloud providers.
             ssl_context = ssl.create_default_context()
             ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+
+        if ssl_context:
+            if ssl_root_cert:
+                ssl_context.load_verify_locations(cafile=ssl_root_cert)
             connect_args["ssl"] = ssl_context
 
     return connect_args, query_params

--- a/backend/database.py
+++ b/backend/database.py
@@ -99,14 +99,24 @@ def configure_ssl_context(query_params: dict):
             ssl_context.verify_mode = ssl.CERT_REQUIRED
             connect_args["ssl"] = ssl_context
 
-        # Require: Encryption required, but verification optional (Legacy/Compat)
+        # Require: Encryption required, and now verification is enforced for security.
         elif ssl_mode == "require":
-            # Create a custom SSL context to avoid certificate verification errors
-            # which are common in some deployment environments (e.g. Render, self-signed)
             ssl_context = ssl.create_default_context()
             ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
             connect_args["ssl"] = ssl_context
+
+    # Support for custom CA bundle
+    if "sslrootcert" in query_params:
+        root_cert = query_params.pop("sslrootcert")
+        # Ensure we have an SSL context if sslrootcert is provided
+        if "ssl" not in connect_args:
+            ssl_context = ssl.create_default_context()
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            connect_args["ssl"] = ssl_context
+
+        connect_args["ssl"].load_verify_locations(cafile=root_cert)
 
     return connect_args, query_params
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,5 +1,4 @@
 
-import os
 import ssl
 from datetime import datetime
 from typing import List, Optional, Any, Dict

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,7 +22,8 @@ from .council import (
     run_full_council, generate_conversation_title,
     stage1_collect_responses, stage1_collect_responses_six_hats,
     stage2_collect_rankings, stage2_collect_critiques,
-    stage3_synthesize_final, calculate_aggregate_rankings, resolve_active_models
+    stage3_synthesize_final, calculate_aggregate_rankings, resolve_active_models,
+    build_model_weight_profile, apply_round_to_model_profiles, serialize_model_weight_profile
 )
 from . import export
 
@@ -82,7 +83,7 @@ class CreateConversationRequest(BaseModel):
     @field_validator("framework")
     @classmethod
     def validate_framework(cls, v: str) -> str:
-        allowed = {"standard", "six_hats", "debate", "ensemble"}
+        allowed = {"standard", "six_hats", "debate", "ensemble", "heterogeneous"}
         if v not in allowed:
             raise ValueError(f"Framework must be one of: {', '.join(allowed)}")
         return v
@@ -485,7 +486,8 @@ async def send_message(
         council_models=council_models,
         chairman_model=chairman_model,
         retrieval_context=retrieval_context,
-        retrieval_citations=citations
+        retrieval_citations=citations,
+        conversation_messages=conversation.get("messages")
     )
 
     # Add assistant message with all stages
@@ -565,10 +567,15 @@ async def _rerun_stage2_and_stage3(
     stage1_results: List[Dict[str, Any]],
     effective_models: List[str],
     chairman_model: Optional[str],
-    retrieval_context: str
+    retrieval_context: str,
+    conversation_messages: Optional[List[Dict[str, Any]]] = None
 ) -> Dict[str, Any]:
     stage2_results: List[Dict[str, Any]] = []
     aggregate_rankings: List[Dict[str, Any]] = []
+    model_profiles = (
+        build_model_weight_profile(conversation_messages, effective_models)
+        if framework == "heterogeneous" else {}
+    )
 
     if framework == "ensemble":
         label_to_model = _build_response_label_mapping(stage1_results)
@@ -585,9 +592,20 @@ async def _rerun_stage2_and_stage3(
             stage1_results,
             effective_models,
             chairman_model,
-            retrieval_context=retrieval_context
+            retrieval_context=retrieval_context,
+            framework=framework,
+            model_profiles=model_profiles
         )
         aggregate_rankings = calculate_aggregate_rankings(stage2_results, label_to_model)
+
+    updated_model_profiles = (
+        apply_round_to_model_profiles(
+            model_profiles,
+            aggregate_rankings,
+            [result["model"] for result in stage1_results]
+        )
+        if framework == "heterogeneous" and aggregate_rankings else model_profiles
+    )
 
     full_stage3_response = ""
     async for token in stage3_synthesize_final(
@@ -596,7 +614,8 @@ async def _rerun_stage2_and_stage3(
         stage2_results,
         chairman_model=chairman_model,
         mode=framework,
-        retrieval_context=retrieval_context
+        retrieval_context=retrieval_context,
+        aggregate_rankings=aggregate_rankings
     ):
         full_stage3_response += token
 
@@ -613,6 +632,13 @@ async def _rerun_stage2_and_stage3(
         "stage3": stage3_result,
         "label_to_model": label_to_model,
         "aggregate_rankings": aggregate_rankings,
+        "model_weight_profile": serialize_model_weight_profile(updated_model_profiles, effective_models)
+        if framework == "heterogeneous" else [],
+        "ballot_weighting": {
+            "mode": "confidence_x_rolling_performance",
+            "confidence_source": "stage2_self_report",
+            "history_source": "prior_conversation_rankings",
+        } if framework == "heterogeneous" else None,
     }
 
 
@@ -799,12 +825,17 @@ async def retry_failed_stage1_models(
                     stage1_results=merged_stage1,
                     effective_models=effective_models,
                     chairman_model=active_chairman_model,
-                    retrieval_context=retrieval_context
+                    retrieval_context=retrieval_context,
+                    conversation_messages=messages[:message_index]
                 )
                 target_message["stage2"] = refreshed_data["stage2"]
                 target_message["stage3"] = refreshed_data["stage3"]
                 metadata["label_to_model"] = refreshed_data["label_to_model"]
                 metadata["aggregate_rankings"] = refreshed_data["aggregate_rankings"]
+                if refreshed_data.get("model_weight_profile"):
+                    metadata["model_weight_profile"] = refreshed_data["model_weight_profile"]
+                if refreshed_data.get("ballot_weighting"):
+                    metadata["ballot_weighting"] = refreshed_data["ballot_weighting"]
                 metadata["synthesis_refreshed_at_ms"] = int(time.time() * 1000)
                 metadata["synthesis_refresh_duration_seconds"] = round(time.monotonic() - refresh_started_at, 3)
                 metadata.pop("synthesis_refresh_error", None)
@@ -850,6 +881,10 @@ async def send_message_stream(
     chairman_model = conversation.get("chairman_model")
     requested_council_models = list(council_models) if council_models else []
     effective_council_models = resolve_active_models(council_models)
+    model_profiles = (
+        build_model_weight_profile(conversation.get("messages"), effective_council_models)
+        if framework == "heterogeneous" else {}
+    )
 
     async def event_generator():
         overall_start = time.monotonic()
@@ -933,6 +968,7 @@ async def send_message_stream(
             stage2_results = []
             aggregate_rankings = []
             label_to_model = {}
+            updated_model_profiles = model_profiles
             retrieval_meta = {"retrieval": {"citations": citations}}
             config_meta = {
                 "requested_council_models": requested_council_models,
@@ -940,6 +976,7 @@ async def send_message_stream(
                 "responded_council_models": responded_council_models,
                 "stage1_errors": stage1_errors,
             }
+            hetero_meta = {}
 
             if framework == "ensemble":
                 label_to_model = {f"Response {chr(65+i)}": r['model'] for i, r in enumerate(stage1_results)}
@@ -954,16 +991,35 @@ async def send_message_stream(
                  )
                  yield f"data: {json.dumps({'type': 'stage2_complete', 'data': stage2_results, 'metadata': {'label_to_model': label_to_model, 'mode': 'debate', **config_meta, **retrieval_meta}})}\n\n"
 
-            else: # standard and six_hats both use ranking for Stage 2
+            else: # standard, six_hats, and heterogeneous all use ranking for Stage 2
                  stage2_results, label_to_model = await stage2_collect_rankings(
                      request.content,
                      stage1_results,
                      effective_council_models,
                      chairman_model,
-                     retrieval_context=retrieval_context
+                     retrieval_context=retrieval_context,
+                     framework=framework,
+                     model_profiles=model_profiles
                  )
                  aggregate_rankings = calculate_aggregate_rankings(stage2_results, label_to_model)
-                 yield f"data: {json.dumps({'type': 'stage2_complete', 'data': stage2_results, 'metadata': {'label_to_model': label_to_model, 'aggregate_rankings': aggregate_rankings, **config_meta, **retrieval_meta}})}\n\n"
+                 if framework == "heterogeneous":
+                     updated_model_profiles = apply_round_to_model_profiles(
+                         model_profiles,
+                         aggregate_rankings,
+                         responded_council_models
+                     )
+                     hetero_meta = {
+                         "model_weight_profile": serialize_model_weight_profile(
+                             updated_model_profiles,
+                             effective_council_models
+                         ),
+                         "ballot_weighting": {
+                             "mode": "confidence_x_rolling_performance",
+                             "confidence_source": "stage2_self_report",
+                             "history_source": "prior_conversation_rankings",
+                         },
+                     }
+                 yield f"data: {json.dumps({'type': 'stage2_complete', 'data': stage2_results, 'metadata': {'label_to_model': label_to_model, 'aggregate_rankings': aggregate_rankings, **hetero_meta, **config_meta, **retrieval_meta}})}\n\n"
 
             stage2_duration = round(time.monotonic() - stage2_start, 3)
             print(
@@ -981,7 +1037,8 @@ async def send_message_stream(
                 stage2_results,
                 chairman_model=chairman_model,
                 mode=framework,
-                retrieval_context=retrieval_context
+                retrieval_context=retrieval_context,
+                aggregate_rankings=aggregate_rankings
             ):
                 full_stage3_response += token
                 yield f"data: {json.dumps({'type': 'stage3_token', 'data': token})}\n\n"
@@ -1022,6 +1079,16 @@ async def send_message_stream(
                 },
                 **retrieval_meta
             }
+            if framework == "heterogeneous":
+                metadata["model_weight_profile"] = serialize_model_weight_profile(
+                    updated_model_profiles,
+                    effective_council_models
+                )
+                metadata["ballot_weighting"] = {
+                    "mode": "confidence_x_rolling_performance",
+                    "confidence_source": "stage2_self_report",
+                    "history_source": "prior_conversation_rankings",
+                }
             await storage.add_assistant_message(
                 conversation_id,
                 user_id,

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 """FastAPI backend for LLM Council."""
 
-from fastapi import FastAPI, HTTPException, Depends, UploadFile, File, status
+from fastapi import FastAPI, HTTPException, Depends, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse, FileResponse
 from fastapi.staticfiles import StaticFiles

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ import os
 import io
 import time
 import requests
+import logging
 from contextlib import asynccontextmanager
 
 from . import storage, auth, openrouter, security, documents, retrieval, config
@@ -25,6 +26,8 @@ from .council import (
     stage3_synthesize_final, calculate_aggregate_rankings, resolve_active_models
 )
 from . import export
+
+logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -250,8 +253,8 @@ async def delete_conversation(conversation_id: str, user_id: str = Depends(auth.
         return {"status": "success"}
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        print(f"Error deleting conversation: {e}")
+    except Exception:
+        logger.error("Error deleting conversation", exc_info=False)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -261,8 +264,8 @@ async def list_models(user_id: str = Depends(auth.get_current_user_id)):
     try:
         models = await openrouter.fetch_models()
         return models
-    except Exception as e:
-        print(f"Error fetching models: {e}")
+    except Exception:
+        logger.error("Error fetching models", exc_info=False)
         # Security: Do not leak internal error details to client
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -1039,10 +1042,8 @@ async def send_message_stream(
                 f"responded={responded_council_models}"
             )
 
-        except Exception as e:
-            import traceback
-            traceback.print_exc()
-            print(f"Streaming error: {e}")
+        except Exception:
+            logger.error("Streaming error", exc_info=False)
             # Security: Do not leak internal error details to client
             yield f"data: {json.dumps({'type': 'error', 'error': 'An internal error occurred.'})}\n\n"
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ import asyncio
 import os
 import io
 import time
-import requests
+import logging
 from contextlib import asynccontextmanager
 
 from . import storage, auth, openrouter, security, documents, retrieval, config
@@ -25,6 +25,8 @@ from .council import (
     stage3_synthesize_final, calculate_aggregate_rankings, resolve_active_models
 )
 from . import export
+
+logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -250,8 +252,8 @@ async def delete_conversation(conversation_id: str, user_id: str = Depends(auth.
         return {"status": "success"}
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        print(f"Error deleting conversation: {e}")
+    except Exception:
+        logger.exception("Error deleting conversation")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
@@ -261,8 +263,8 @@ async def list_models(user_id: str = Depends(auth.get_current_user_id)):
     try:
         models = await openrouter.fetch_models()
         return models
-    except Exception as e:
-        print(f"Error fetching models: {e}")
+    except Exception:
+        logger.exception("Error fetching models")
         # Security: Do not leak internal error details to client
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -879,7 +881,7 @@ async def send_message_stream(
                 retrieval.build_retrieval_context(conversation_id, user_id, request.content)
             )
 
-            print(
+            logger.info(
                 f"[stream] conversation={conversation_id} framework={framework} "
                 f"requested_models={requested_council_models} effective_models={effective_council_models} "
                 f"chairman={chairman_model or config.CHAIRMAN_MODEL}"
@@ -918,7 +920,7 @@ async def send_message_stream(
                 "stage1_duration_seconds": stage1_duration,
             }
             yield f"data: {json.dumps({'type': 'stage1_complete', 'data': stage1_results, 'metadata': stage1_meta})}\n\n"
-            print(
+            logger.info(
                 f"[stream] conversation={conversation_id} stage1_complete duration={stage1_duration}s "
                 f"responded={responded_council_models} errors={len(stage1_errors)}"
             )
@@ -966,7 +968,7 @@ async def send_message_stream(
                  yield f"data: {json.dumps({'type': 'stage2_complete', 'data': stage2_results, 'metadata': {'label_to_model': label_to_model, 'aggregate_rankings': aggregate_rankings, **config_meta, **retrieval_meta}})}\n\n"
 
             stage2_duration = round(time.monotonic() - stage2_start, 3)
-            print(
+            logger.info(
                 f"[stream] conversation={conversation_id} stage2_complete duration={stage2_duration}s "
                 f"framework={framework}"
             )
@@ -995,7 +997,7 @@ async def send_message_stream(
             }
             yield f"data: {json.dumps({'type': 'stage3_complete', 'data': stage3_result})}\n\n"
             stage3_duration = round(time.monotonic() - stage3_start, 3)
-            print(f"[stream] conversation={conversation_id} stage3_complete duration={stage3_duration}s")
+            logger.info(f"[stream] conversation={conversation_id} stage3_complete duration={stage3_duration}s")
 
             # Wait for title generation if it was started
             if title_task:
@@ -1033,16 +1035,14 @@ async def send_message_stream(
 
             # Send completion event
             yield f"data: {json.dumps({'type': 'complete'})}\n\n"
-            print(
+            logger.info(
                 f"[stream] conversation={conversation_id} complete total={metadata['timing']['total_seconds']}s "
                 f"requested={requested_council_models} effective={effective_council_models} "
                 f"responded={responded_council_models}"
             )
 
-        except Exception as e:
-            import traceback
-            traceback.print_exc()
-            print(f"Streaming error: {e}")
+        except Exception:
+            logger.exception("Streaming error")
             # Security: Do not leak internal error details to client
             yield f"data: {json.dumps({'type': 'error', 'error': 'An internal error occurred.'})}\n\n"
 

--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -117,12 +117,13 @@ async def fetch_models() -> List[Dict[str, Any]]:
             
     except httpx.HTTPStatusError as e:
         message = _extract_error_message(e.response)
+        logger.error(f"OpenRouter status error: {e.response.status_code}")
         raise RuntimeError(
             f"OpenRouter error {e.response.status_code}: {message}"
         ) from e
-    except Exception as e:
-        print(f"Error fetching models: {e}")
-        raise e
+    except Exception:
+        logger.exception("Error fetching models")
+        raise RuntimeError("Failed to fetch models from OpenRouter.")
 
 async def query_model(
     model: str,
@@ -245,12 +246,12 @@ async def query_model(
             "error": error_message,
             "status_code": e.response.status_code,
         }
-    except Exception as e:
+    except Exception:
         logger.exception("Error querying model %s", model)
         return {
             "content": None,
             "reasoning_details": None,
-            "error": str(e),
+            "error": "An internal error occurred while querying the model.",
             "status_code": None,
         }
 

--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -117,11 +117,12 @@ async def fetch_models() -> List[Dict[str, Any]]:
             
     except httpx.HTTPStatusError as e:
         message = _extract_error_message(e.response)
+        logger.error("OpenRouter error %s: %s", e.response.status_code, message)
         raise RuntimeError(
             f"OpenRouter error {e.response.status_code}: {message}"
         ) from e
     except Exception as e:
-        print(f"Error fetching models: {e}")
+        logger.error("Error fetching models", exc_info=False)
         raise e
 
 async def query_model(
@@ -246,7 +247,7 @@ async def query_model(
             "status_code": e.response.status_code,
         }
     except Exception as e:
-        logger.exception("Error querying model %s", model)
+        logger.error("Error querying model %s", model, exc_info=False)
         return {
             "content": None,
             "reasoning_details": None,
@@ -361,5 +362,5 @@ async def query_model_stream(
                 logger.warning("OpenRouter stream for %s closed without [DONE] marker.", model)
 
     except Exception as e:
-        logger.exception("Error querying model stream %s", model)
-        raise RuntimeError(f"Streaming failed for model {model}: {e}") from e
+        logger.error("Error querying model stream %s", model, exc_info=False)
+        raise RuntimeError(f"Streaming failed for model {model}") from e

--- a/backend/retrieval.py
+++ b/backend/retrieval.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import numpy as np
+import logging
 from typing import List, Dict, Any, Tuple
 from starlette.concurrency import run_in_threadpool
 
 from . import storage, documents
 from .config import RETRIEVAL_TOP_K, RETRIEVAL_MAX_TOTAL_CHARS, RETRIEVAL_MAX_CHARS_PER_CHUNK
 
+logger = logging.getLogger(__name__)
 
 def _build_context(citations: List[Dict[str, Any]]) -> str:
     if not citations:
@@ -110,8 +112,6 @@ async def build_retrieval_context(
 
         context = _build_context(citations)
         return (context if context else None), citations
-    except Exception as e:
-        import traceback
-        traceback.print_exc()
-        print(f"Retrieval error: {e}")
+    except Exception:
+        logger.exception("Retrieval error")
         return None, []

--- a/backend/retrieval.py
+++ b/backend/retrieval.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import numpy as np
+import logging
 from typing import List, Dict, Any, Tuple
 from starlette.concurrency import run_in_threadpool
 
 from . import storage, documents
 from .config import RETRIEVAL_TOP_K, RETRIEVAL_MAX_TOTAL_CHARS, RETRIEVAL_MAX_CHARS_PER_CHUNK
 
+logger = logging.getLogger(__name__)
 
 def _build_context(citations: List[Dict[str, Any]]) -> str:
     if not citations:
@@ -110,8 +112,6 @@ async def build_retrieval_context(
 
         context = _build_context(citations)
         return (context if context else None), citations
-    except Exception as e:
-        import traceback
-        traceback.print_exc()
-        print(f"Retrieval error: {e}")
+    except Exception:
+        logger.error("Retrieval error", exc_info=False)
         return None, []

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -269,18 +269,7 @@ async def db_get_document_chunks_by_ids(conversation_id: str, user_id: str, chun
 
 async def db_delete_document(conversation_id: str, document_id: str, user_id: str):
     async with AsyncSessionLocal() as session:
-        result = await session.execute(
-            select(DocumentModel)
-            .where(
-                DocumentModel.id == document_id,
-                DocumentModel.conversation_id == conversation_id,
-                DocumentModel.user_id == user_id
-            )
-        )
-        doc = result.scalar_one_or_none()
-        if not doc:
-            raise ValueError("Unauthorized or not found")
-
+        # Delete chunks first (no cascade)
         await session.execute(
             delete(DocumentChunkModel)
             .where(
@@ -289,7 +278,21 @@ async def db_delete_document(conversation_id: str, document_id: str, user_id: st
                 DocumentChunkModel.user_id == user_id
             )
         )
-        await session.delete(doc)
+
+        # Delete the document directly and check rowcount for existence/auth
+        result = await session.execute(
+            delete(DocumentModel)
+            .where(
+                DocumentModel.id == document_id,
+                DocumentModel.conversation_id == conversation_id,
+                DocumentModel.user_id == user_id
+            )
+        )
+
+        if result.rowcount == 0:
+            await session.rollback()
+            raise ValueError("Unauthorized or not found")
+
         await session.commit()
 
 def _model_to_dict(model: ConversationModel) -> Dict[str, Any]:

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -1,13 +1,12 @@
 
 import json
 import os
-import asyncio
 import uuid
 from datetime import datetime
 from typing import List, Dict, Any, Optional
 from pathlib import Path
 from sqlalchemy.future import select
-from sqlalchemy import update, delete, insert
+from sqlalchemy import delete, insert
 from sqlalchemy.orm.attributes import flag_modified
 from .config import DATA_DIR, APP_ORIGIN, DOCUMENTS_DIR
 from .database import AsyncSessionLocal, ConversationModel, DocumentModel, DocumentChunkModel, init_db

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -534,10 +534,18 @@ def file_delete_document(conversation_id: str, document_id: str, user_id: str):
     bundle = load_documents_bundle(conversation_id)
     documents = bundle.get("documents", [])
     chunks = bundle.get("chunks", [])
-    new_documents = [doc for doc in documents if not (doc.get("id") == document_id and doc.get("user_id") == user_id)]
-    if len(new_documents) == len(documents):
+
+    found_idx = -1
+    for i, doc in enumerate(documents):
+        if doc.get("id") == document_id and doc.get("user_id") == user_id:
+            found_idx = i
+            break
+
+    if found_idx == -1:
         raise ValueError("Unauthorized or not found")
-    bundle["documents"] = new_documents
+
+    documents.pop(found_idx)
+    bundle["documents"] = documents
     bundle["chunks"] = [chunk for chunk in chunks if chunk.get("document_id") != document_id]
     save_documents_bundle(conversation_id, bundle)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "8000:8000"
     environment:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-dev_secret_key_change_in_production}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
     volumes:
       - ./data:/app/data

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test src/**/*.test.js"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,7 @@ import { api } from './api';
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/toaster";
 import { useToast } from "@/components/ui/use-toast";
-import { Moon, Sun, Menu, LogOut } from "lucide-react";
+import { Moon, Sun, Menu, LogOut, ListTree } from "lucide-react";
 
 const Login = lazy(() => import('./components/Login'));
 import { useAuth } from './contexts/AuthContextDefinition';
@@ -36,6 +36,7 @@ function App() {
   const mobileBreakpoint = 768; // Tailwind md
   const [isMobile, setIsMobile] = useState(window.innerWidth < mobileBreakpoint);
   const [isSidebarOpen, setIsSidebarOpen] = useState(window.innerWidth >= mobileBreakpoint);
+  const [isNavigatorOpen, setIsNavigatorOpen] = useState(false);
 
   // ... (Keep existing loadConversations, loadConversation logic) ...
   const loadConversations = useCallback(async () => {
@@ -142,6 +143,10 @@ function App() {
 
   const handleSidebarClose = useCallback(() => {
     setIsSidebarOpen(false);
+  }, []);
+
+  const toggleNavigator = useCallback(() => {
+    setIsNavigatorOpen((current) => !current);
   }, []);
 
   // Optimize Sidebar re-renders by extracting only necessary metadata
@@ -514,6 +519,16 @@ function App() {
           )}
           <div className="flex-1" />
 
+          <Button
+            variant={isNavigatorOpen ? "secondary" : "ghost"}
+            size="icon"
+            onClick={toggleNavigator}
+            title={isNavigatorOpen ? "Close Navigator" : "Open Navigator"}
+            disabled={!currentConversation}
+          >
+            <ListTree className="h-5 w-5" />
+          </Button>
+
           <Button variant="ghost" size="icon" onClick={toggleTheme} title="Toggle Theme">
             {theme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
           </Button>
@@ -534,6 +549,8 @@ function App() {
             onRetryFailedModels={handleRetryFailedModels}
             isLoading={isLoading}
             isMobile={isMobile}
+            isNavigatorOpen={isNavigatorOpen}
+            onNavigatorOpenChange={setIsNavigatorOpen}
           />
         </main>
       </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback, lazy, Suspense, useMemo } from 'react
 import CouncilSidebar from './components/CouncilSidebar';
 import ChatInterface from './components/ChatInterface';
 import { api } from './api';
+import { logger } from '@/lib/logger';
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/toaster";
 import { useToast } from "@/components/ui/use-toast";
@@ -44,7 +45,7 @@ function App() {
       const convs = await api.listConversations();
       setConversations(convs);
     } catch (error) {
-      console.error('Failed to load conversations:', error);
+      logger.error('Failed to load conversations:', error);
       if (error.message.includes('401') || error.message.includes('Unauthorized')) {
         logout();
       }
@@ -56,7 +57,7 @@ function App() {
       const conv = await api.getConversation(id);
       setCurrentConversation(conv);
     } catch (error) {
-      console.error('Failed to load conversation:', error);
+      logger.error('Failed to load conversation:', error);
     }
   }, []);
 
@@ -125,7 +126,7 @@ function App() {
       window.history.pushState({ path: newUrl }, '', newUrl);
       return data;
     } catch (error) {
-      console.error('Failed to create conversation:', error);
+      logger.error('Failed to create conversation:', error);
       throw error;
     } finally {
       setIsLoading(false);
@@ -338,7 +339,7 @@ function App() {
             setIsLoading(false);
             break;
           case 'error':
-            console.error('Stream error:', event.error);
+            logger.error('Stream error:', event.error);
             setCurrentConversation((prev) => {
               const messages = [...prev.messages];
               const lastIndex = messages.length - 1;
@@ -374,7 +375,7 @@ function App() {
         }
       });
     } catch (error) {
-      console.error('Failed to send message:', error);
+      logger.error('Failed to send message:', error);
       setCurrentConversation((prev) => ({
         ...prev,
         messages: prev.messages.slice(0, -2),

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, lazy, Suspense, useMemo } from 'react';
-// import Sidebar from './components/Sidebar';
 import CouncilSidebar from './components/CouncilSidebar';
 import ChatInterface from './components/ChatInterface';
 import { api } from './api';
@@ -10,7 +9,6 @@ import { Moon, Sun, Menu, LogOut } from "lucide-react";
 
 const Login = lazy(() => import('./components/Login'));
 import { useAuth } from './contexts/AuthContextDefinition';
-// import './App.css'; // Deprecated
 
 function App() {
   const { user, isLoading: authLoading, logout } = useAuth();

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,7 @@
 /**
  * API client for the LLM Council backend.
  */
+import { logger } from '@/lib/logger';
 
 // Use localhost in development, relative path in production (same origin)
 const API_BASE = import.meta.env.DEV ? 'http://localhost:8001' : '';
@@ -243,7 +244,7 @@ export const api = {
               }
               onEvent(event.type, event);
             } catch (e) {
-              console.error('Failed to parse SSE event:', e);
+              logger.error('Failed to parse SSE event:', e);
             }
           }
         }
@@ -258,11 +259,11 @@ export const api = {
           }
           onEvent(event.type, event);
         } catch (e) {
-          console.error('Failed to parse (final) SSE event:', e);
+          logger.error('Failed to parse (final) SSE event:', e);
         }
       }
     } catch (error) {
-      console.error('SSE stream failed:', error);
+      logger.error('SSE stream failed:', error);
       if (!receivedTerminalEvent) {
         onEvent('error', {
           type: 'error',

--- a/frontend/src/components/ChatHeader.jsx
+++ b/frontend/src/components/ChatHeader.jsx
@@ -3,7 +3,7 @@ import React, { memo } from 'react';
 import { api } from '../api';
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Download, Link as LinkIcon, FileText, Check, ListTree } from "lucide-react";
+import { Download, Link as LinkIcon, FileText, Check } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -25,8 +25,6 @@ const ChatHeader = memo(({
   framework,
   councilModels,
   chairmanModel,
-  onToggleNavigator,
-  isNavigatorOpen = false,
   navigatorItemCount = 0,
 }) => {
   const { toast } = useToast();
@@ -85,22 +83,6 @@ const ChatHeader = memo(({
       </div>
       <div className="flex items-center gap-1">
         <TooltipProvider>
-          {typeof onToggleNavigator === 'function' && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant={isNavigatorOpen ? "secondary" : "ghost"}
-                  size="icon"
-                  onClick={onToggleNavigator}
-                  aria-label={isNavigatorOpen ? "Close conversation navigator" : "Open conversation navigator"}
-                >
-                  <ListTree className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{isNavigatorOpen ? 'Close Navigator' : 'Open Navigator'}</TooltipContent>
-            </Tooltip>
-          )}
-
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant="ghost" size="icon" onClick={() => handleExport('md')}>

--- a/frontend/src/components/ChatHeader.jsx
+++ b/frontend/src/components/ChatHeader.jsx
@@ -18,6 +18,7 @@ const FRAMEWORK_LABELS = {
   debate: 'Chain of Debate',
   six_hats: 'Six Thinking Hats',
   ensemble: 'Ensemble (Fast)',
+  heterogeneous: 'Heterogeneous Council',
 };
 
 const ChatHeader = memo(({

--- a/frontend/src/components/ChatHeader.jsx
+++ b/frontend/src/components/ChatHeader.jsx
@@ -1,6 +1,7 @@
 
 import React, { memo } from 'react';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Download, Link as LinkIcon, FileText, Check } from "lucide-react";
@@ -42,7 +43,7 @@ const ChatHeader = memo(({
         description: `Exporting conversation to ${format.toUpperCase()}...`,
       });
     } catch (error) {
-      console.error('Export failed:', error);
+      logger.error('Export failed:', error);
       toast({
         variant: "destructive",
         title: "Export Failed",
@@ -61,7 +62,7 @@ const ChatHeader = memo(({
       });
       setTimeout(() => setCopied(false), 2000);
     }).catch(err => {
-      console.error('Failed to copy link:', err);
+      logger.error('Failed to copy link:', err);
       toast({
         variant: "destructive",
         title: "Error",

--- a/frontend/src/components/ChatInput.jsx
+++ b/frontend/src/components/ChatInput.jsx
@@ -1,6 +1,7 @@
 
 import React, { memo, useState, useEffect, useRef } from 'react';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -41,7 +42,7 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage }) => {
         const docs = await api.listDocuments(conversationId);
         setDocuments(docs);
       } catch (error) {
-        console.error('Failed to load documents:', error);
+        logger.error('Failed to load documents:', error);
       }
     };
 
@@ -106,7 +107,7 @@ const ChatInput = memo(({ conversationId, isLoading, onSendMessage }) => {
       const updatedDocuments = await api.listDocuments(conversationId);
       setDocuments(updatedDocuments);
     } catch (error) {
-      console.error('Upload failed:', error);
+      logger.error('Upload failed:', error);
       setUploadError('Failed to upload documents.');
     } finally {
       setUploading(false);

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -18,11 +18,12 @@ export default function ChatInterface({
   onRetryFailedModels,
   isLoading,
   isMobile = false,
+  isNavigatorOpen = false,
+  onNavigatorOpenChange,
 }) {
   const messagesEndRef = useRef(null);
   const messagesContainerRef = useRef(null);
   const highlightTimeoutRef = useRef(null);
-  const [isNavigatorOpen, setIsNavigatorOpen] = useState(false);
   const [activeAnchorId, setActiveAnchorId] = useState(null);
   const [highlightedAnchorId, setHighlightedAnchorId] = useState(null);
   const [shouldAutoFollow, setShouldAutoFollow] = useState(true);
@@ -66,6 +67,12 @@ export default function ChatInterface({
     }, 1800);
   }, []);
 
+  const setNavigatorOpen = useCallback((nextOpen) => {
+    if (typeof onNavigatorOpenChange === 'function') {
+      onNavigatorOpenChange(Boolean(nextOpen));
+    }
+  }, [onNavigatorOpenChange]);
+
   const handleJumpToLatest = useCallback(() => {
     const latestAnchorId = outlineItems[outlineItems.length - 1]?.anchorId || null;
     if (latestAnchorId) {
@@ -76,9 +83,25 @@ export default function ChatInterface({
     setIsNearBottom(true);
     scrollToBottom('smooth');
     if (isMobile) {
-      setIsNavigatorOpen(false);
+      setNavigatorOpen(false);
     }
-  }, [highlightAnchor, isMobile, outlineItems, scrollToBottom]);
+  }, [highlightAnchor, isMobile, outlineItems, scrollToBottom, setNavigatorOpen]);
+
+  const handleJumpToTop = useCallback(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    const firstAnchorId = outlineItems[0]?.anchorId || null;
+    if (firstAnchorId) {
+      setActiveAnchorId(firstAnchorId);
+      highlightAnchor(firstAnchorId);
+    }
+    setShouldAutoFollow(false);
+    setIsNearBottom(false);
+    container.scrollTo({ top: 0, behavior: 'smooth' });
+    if (isMobile) {
+      setNavigatorOpen(false);
+    }
+  }, [highlightAnchor, isMobile, outlineItems, setNavigatorOpen]);
 
   const handleJumpToAnchor = useCallback((anchorId) => {
     if (!anchorId) return;
@@ -92,15 +115,19 @@ export default function ChatInterface({
     target.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
     if (isMobile) {
-      setIsNavigatorOpen(false);
+      setNavigatorOpen(false);
     }
-  }, [highlightAnchor, isMobile]);
+  }, [highlightAnchor, isMobile, setNavigatorOpen]);
 
   const handleJumpToFirst = useCallback(() => {
     const firstAnchorId = outlineItems[0]?.anchorId;
     if (!firstAnchorId) return;
+    if (outlineItems.length <= 1) {
+      handleJumpToTop();
+      return;
+    }
     handleJumpToAnchor(firstAnchorId);
-  }, [handleJumpToAnchor, outlineItems]);
+  }, [handleJumpToAnchor, handleJumpToTop, outlineItems]);
 
   const handleMessagesScroll = useCallback(() => {
     const nearBottom = isNearBottomInViewport();
@@ -217,8 +244,6 @@ export default function ChatInterface({
           framework={conversation.framework}
           councilModels={conversation.council_models}
           chairmanModel={conversation.chairman_model}
-          onToggleNavigator={() => setIsNavigatorOpen((current) => !current)}
-          isNavigatorOpen={isNavigatorOpen}
           navigatorItemCount={outlineItems.length}
         />
 
@@ -291,16 +316,17 @@ export default function ChatInterface({
           <ConversationNavigator
             items={outlineItems}
             activeAnchorId={resolvedActiveAnchorId}
+            onJumpToTop={handleJumpToTop}
             onJumpToAnchor={handleJumpToAnchor}
             onJumpToFirst={handleJumpToFirst}
             onJumpToLatest={handleJumpToLatest}
-            onClose={() => setIsNavigatorOpen(false)}
+            onClose={() => setNavigatorOpen(false)}
           />
         </aside>
       )}
 
       {isMobile && (
-        <Dialog open={isNavigatorOpen} onOpenChange={setIsNavigatorOpen}>
+        <Dialog open={isNavigatorOpen} onOpenChange={setNavigatorOpen}>
           <DialogContent className="left-0 right-0 top-auto bottom-0 h-[78vh] max-w-none translate-x-0 translate-y-0 rounded-b-none rounded-t-xl p-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom">
             <DialogTitle className="sr-only">Conversation Navigator</DialogTitle>
             <DialogDescription className="sr-only">
@@ -309,10 +335,11 @@ export default function ChatInterface({
             <ConversationNavigator
               items={outlineItems}
               activeAnchorId={resolvedActiveAnchorId}
+              onJumpToTop={handleJumpToTop}
               onJumpToAnchor={handleJumpToAnchor}
               onJumpToFirst={handleJumpToFirst}
               onJumpToLatest={handleJumpToLatest}
-              onClose={() => setIsNavigatorOpen(false)}
+              onClose={() => setNavigatorOpen(false)}
             />
           </DialogContent>
         </Dialog>

--- a/frontend/src/components/ConversationNavigator.jsx
+++ b/frontend/src/components/ConversationNavigator.jsx
@@ -21,6 +21,7 @@ const filterOutlineItems = (items, query) => {
 const ConversationNavigator = ({
   items = [],
   activeAnchorId,
+  onJumpToTop,
   onJumpToAnchor,
   onJumpToFirst,
   onJumpToLatest,
@@ -65,29 +66,40 @@ const ConversationNavigator = ({
           />
         </div>
 
-        <div className="flex gap-2">
+        <div className="grid grid-cols-3 gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onJumpToTop}
+            disabled={items.length === 0}
+            className="w-full"
+            aria-label="Jump to top"
+          >
+            Top
+          </Button>
           <Button
             type="button"
             variant="outline"
             size="sm"
             onClick={onJumpToFirst}
             disabled={items.length === 0}
-            className="flex-1"
+            className="w-full"
             aria-label="Jump to first turn"
           >
             <ArrowUp className="mr-1 h-3.5 w-3.5" />
-            Jump to first
+            First
           </Button>
           <Button
             type="button"
             variant="outline"
             size="sm"
             onClick={onJumpToLatest}
-            className="flex-1"
+            className="w-full"
             aria-label="Jump to latest turn"
           >
             <ArrowDown className="mr-1 h-3.5 w-3.5" />
-            Jump to latest
+            Latest
           </Button>
         </div>
       </div>

--- a/frontend/src/components/CouncilConfigDialog.jsx
+++ b/frontend/src/components/CouncilConfigDialog.jsx
@@ -35,6 +35,12 @@ const COUNCIL_TYPES = [
     framework: 'ensemble',
     description: 'Parallel execution for quick consensus without the peer-review stage.',
   },
+  {
+    id: 'heterogeneous',
+    name: 'Heterogeneous Council',
+    framework: 'heterogeneous',
+    description: 'Mixed-model council with confidence-weighted voting and rolling per-model performance weights.',
+  },
 ];
 
 const clampSelectionLimit = (value) => {

--- a/frontend/src/components/CouncilMessageBlock.jsx
+++ b/frontend/src/components/CouncilMessageBlock.jsx
@@ -19,34 +19,60 @@ const MarkdownContent = memo(({ content }) => (
 MarkdownContent.displayName = 'MarkdownContent';
 
 // ⚡ Bolt: Extract and memoize Rankings tab content to prevent re-renders when Stage 3 is streaming
-const RankingsTabContent = memo(({ aggregateRankings }) => (
-  <div className="p-6">
-    <h3 className="font-semibold mb-4">Council Rankings</h3>
-    <div className="space-y-4">
-      {aggregateRankings.length > 0 ? (
-        aggregateRankings.map((rank, idx) => (
-          <div key={idx} className="flex items-center justify-between p-3 border rounded-lg bg-card/50">
-            <div className="flex items-center gap-3">
-              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted font-bold">
-                {idx + 1}
-              </div>
-              <div>
-                <div className="font-medium">{rank.model}</div>
-                <div className="text-xs text-muted-foreground">{rank.rankings_count} evaluations</div>
-              </div>
-            </div>
-            <div className="text-right">
-              <div className="font-mono font-bold text-lg">{rank.average_rank}</div>
-              <div className="text-xs text-muted-foreground">Avg Rank</div>
-            </div>
-          </div>
-        ))
-      ) : (
-        <div className="text-muted-foreground italic">No rankings available for this session type.</div>
+const RankingsTabContent = memo(({ aggregateRankings, framework, modelWeightProfile }) => {
+  const profileByModel = new Map(
+    (Array.isArray(modelWeightProfile) ? modelWeightProfile : [])
+      .filter((entry) => entry && typeof entry.model === 'string')
+      .map((entry) => [entry.model, entry])
+  );
+
+  return (
+    <div className="p-6">
+      <h3 className="font-semibold mb-2">Council Rankings</h3>
+      {framework === 'heterogeneous' && (
+        <p className="mb-4 text-sm text-muted-foreground">
+          Rankings use confidence-weighted ballots multiplied by each model&apos;s rolling council performance.
+        </p>
       )}
+      <div className="space-y-4">
+        {aggregateRankings.length > 0 ? (
+          aggregateRankings.map((rank, idx) => {
+            const profile = profileByModel.get(rank.model);
+            return (
+              <div key={idx} className="flex items-center justify-between p-3 border rounded-lg bg-card/50">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted font-bold">
+                    {idx + 1}
+                  </div>
+                  <div>
+                    <div className="font-medium">{rank.model}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {rank.rankings_count} evaluations
+                      {rank.total_weight ? ` • total weight ${rank.total_weight}` : ''}
+                    </div>
+                    {framework === 'heterogeneous' && profile && (
+                      <div className="text-xs text-muted-foreground">
+                        Next weight {profile.dynamic_weight} • performance {profile.average_performance}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="font-mono font-bold text-lg">{rank.average_rank}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {framework === 'heterogeneous' ? 'Weighted Avg Rank' : 'Avg Rank'}
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <div className="text-muted-foreground italic">No rankings available for this session type.</div>
+        )}
+      </div>
     </div>
-  </div>
-));
+  );
+});
 
 RankingsTabContent.displayName = 'RankingsTabContent';
 
@@ -265,6 +291,9 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
   const hasComparisonDiff = hasStage1 && stage1.length > 1;
 
   const aggregateRankings = metadata?.aggregate_rankings || [];
+  const modelWeightProfile = Array.isArray(metadata?.model_weight_profile)
+    ? metadata.model_weight_profile
+    : [];
 
   const requestedCouncilModels = Array.isArray(metadata?.requested_council_models)
     ? metadata.requested_council_models
@@ -476,7 +505,11 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
           </TabsContent>
 
           <TabsContent value="rankings" className="m-0 focus-visible:ring-0">
-            <RankingsTabContent aggregateRankings={aggregateRankings} />
+            <RankingsTabContent
+              aggregateRankings={aggregateRankings}
+              framework={metadata?.framework}
+              modelWeightProfile={modelWeightProfile}
+            />
           </TabsContent>
 
           <TabsContent value="diff" className="m-0 focus-visible:ring-0">

--- a/frontend/src/components/CouncilSidebar.jsx
+++ b/frontend/src/components/CouncilSidebar.jsx
@@ -14,6 +14,7 @@ const FRAMEWORK_LABELS = {
   debate: 'Chain of Debate',
   six_hats: 'Six Thinking Hats',
   ensemble: 'Ensemble (Fast)',
+  heterogeneous: 'Heterogeneous Council',
 };
 
 const clampSelectionLimit = (value) => {

--- a/frontend/src/components/CouncilSidebar.jsx
+++ b/frontend/src/components/CouncilSidebar.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, memo } from 'react';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
@@ -49,7 +50,7 @@ const readSavedPresets = () => {
         };
       });
   } catch (error) {
-    console.error('Failed to parse presets', error);
+    logger.error('Failed to parse presets', error);
     return [];
   }
 };
@@ -62,7 +63,7 @@ const readFavoriteModels = () => {
     if (!Array.isArray(parsed)) return [];
     return parsed.filter((id) => typeof id === 'string');
   } catch (error) {
-    console.error('Failed to parse favorite models', error);
+    logger.error('Failed to parse favorite models', error);
     return [];
   }
 };
@@ -188,7 +189,7 @@ const CouncilSidebar = memo(({
             .filter((modelId) => availableModelIds.has(modelId))
         );
       } catch (error) {
-        console.error('Failed to load models', error);
+        logger.error('Failed to load models', error);
       }
     };
 
@@ -362,7 +363,7 @@ const CouncilSidebar = memo(({
       setShowConfigDialog(false);
       if (isMobile) onClose();
     } catch (error) {
-      console.error('Failed to create conversation', error);
+      logger.error('Failed to create conversation', error);
       alert('Failed to start a new session. Please try again.');
     } finally {
       setIsCreatingSession(false);

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { GoogleLogin, GoogleOAuthProvider } from '@react-oauth/google';
 import { useAuth } from '../contexts/AuthContextDefinition';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { BrainCircuit } from "lucide-react";
 
@@ -24,7 +25,7 @@ export default function Login() {
                     setGoogleClientId(runtimeClientId);
                 }
             } catch (err) {
-                console.error('Failed to load auth config:', err);
+                logger.error('Failed to load auth config:', err);
             } finally {
                 if (isMounted) {
                     setIsConfigLoading(false);
@@ -54,7 +55,7 @@ export default function Login() {
             const data = await api.login(credentialResponse.credential);
             handleLoginSuccess(data);
         } catch (err) {
-            console.error('Login error:', err);
+            logger.error('Login error:', err);
             setError('Failed to log in with server');
             setIsLoading(false);
         }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -144,6 +144,10 @@ const Sidebar = memo(({
                   <strong>Ensemble (Fast)</strong>
                   <p>Parallel execution for quick consensus without the peer-review stage.</p>
                 </div>
+                <div className="tooltip-item">
+                  <strong>Heterogeneous Council</strong>
+                  <p>Mixed-model council that weights each ballot by declared confidence and recent council performance.</p>
+                </div>
               </div>
             </div>
           </div>
@@ -156,6 +160,7 @@ const Sidebar = memo(({
             <option value="debate">Chain of Debate</option>
             <option value="six_hats">Six Thinking Hats</option>
             <option value="ensemble">Ensemble (Fast)</option>
+            <option value="heterogeneous">Heterogeneous Council</option>
           </select>
         </div>
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, memo } from 'react';
 import './Sidebar.css';
 import { api } from '../api';
+import { logger } from '@/lib/logger';
 import ModelSelect from './ModelSelect';
 
 const Sidebar = memo(({
@@ -37,7 +38,7 @@ const Sidebar = memo(({
       const s = await api.getStatus();
       setStatus(s);
     } catch (e) {
-      console.error("Failed to load status", e);
+      logger.error("Failed to load status", e);
       setStatusError("Error");
     }
   };
@@ -52,7 +53,7 @@ const Sidebar = memo(({
       // Ideally backend defaults should be visible but we don't know them easily without fetching config
       // Let's leave empty and let user know "Default" is used if empty
     } catch (error) {
-      console.error("Failed to load models", error);
+      logger.error("Failed to load models", error);
       setModelsError(error.message || "Failed to load models");
     } finally {
       setLoadingModels(false);
@@ -77,7 +78,7 @@ const Sidebar = memo(({
       // Since we don't have 'onDelete' prop yet, let's ask user to refresh or reload window.
       window.location.reload();
     } catch (err) {
-      console.error("Failed to delete", err);
+      logger.error("Failed to delete", err);
       alert("Failed to delete conversation");
     }
   };

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { AuthContext } from './AuthContextDefinition';
+import { logger } from '@/lib/logger';
 
 export { AuthContext };
 
@@ -23,7 +24,7 @@ export const AuthProvider = ({ children }) => {
         // Dynamically import googleLogout to avoid bundling @react-oauth/google in main chunk
         import('@react-oauth/google').then(({ googleLogout }) => {
             googleLogout();
-        }).catch(err => console.error("Failed to load googleLogout", err));
+        }).catch(err => logger.error("Failed to load googleLogout", err));
 
         setToken(null);
         setUser(null);

--- a/frontend/src/lib/conversationNavigator.test.js
+++ b/frontend/src/lib/conversationNavigator.test.js
@@ -1,0 +1,135 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  buildTurnAnchorId,
+  buildSnippet,
+  getTurnStatus,
+  buildConversationOutline,
+  TURN_ANCHOR_PREFIX,
+  NAVIGATOR_SNIPPET_MAX_LENGTH
+} from './conversationNavigator.js';
+
+describe('conversationNavigator', () => {
+  describe('buildTurnAnchorId', () => {
+    it('should return the correct anchor ID', () => {
+      assert.strictEqual(buildTurnAnchorId(0), `${TURN_ANCHOR_PREFIX}0`);
+      assert.strictEqual(buildTurnAnchorId(5), `${TURN_ANCHOR_PREFIX}5`);
+    });
+  });
+
+  describe('buildSnippet', () => {
+    it('should return (No text) for empty or null input', () => {
+      assert.strictEqual(buildSnippet(''), '(No text)');
+      assert.strictEqual(buildSnippet(null), '(No text)');
+      assert.strictEqual(buildSnippet(undefined), '(No text)');
+    });
+
+    it('should normalize spaces', () => {
+      assert.strictEqual(buildSnippet('  hello   world  '), 'hello world');
+    });
+
+    it('should truncate long text', () => {
+      const longText = 'a'.repeat(NAVIGATOR_SNIPPET_MAX_LENGTH + 10);
+      const expected = 'a'.repeat(NAVIGATOR_SNIPPET_MAX_LENGTH) + '...';
+      assert.strictEqual(buildSnippet(longText), expected);
+    });
+
+    it('should not truncate text at or below max length', () => {
+      const exactText = 'a'.repeat(NAVIGATOR_SNIPPET_MAX_LENGTH);
+      assert.strictEqual(buildSnippet(exactText), exactText);
+    });
+
+    it('should respect custom maxLength', () => {
+       assert.strictEqual(buildSnippet('hello world', 5), 'hello...');
+    });
+  });
+
+  describe('getTurnStatus', () => {
+    it('should return complete if no assistant message and not loading', () => {
+      assert.strictEqual(getTurnStatus(null, false), 'complete');
+    });
+
+    it('should return in_progress if no assistant message and loading', () => {
+      assert.strictEqual(getTurnStatus(null, true), 'in_progress');
+    });
+
+    it('should return in_progress if assistant message is loading', () => {
+      const msg = {
+        role: 'assistant',
+        loading: { stage1: true }
+      };
+      assert.strictEqual(getTurnStatus(msg), 'in_progress');
+    });
+
+    it('should return has_errors if assistant message has direct errors', () => {
+      const msg = {
+        role: 'assistant',
+        errors: ['error']
+      };
+      assert.strictEqual(getTurnStatus(msg), 'has_errors');
+    });
+
+    it('should return has_errors if assistant message has stage1_errors', () => {
+      const msg = {
+        role: 'assistant',
+        metadata: { stage1_errors: ['error'] }
+      };
+      assert.strictEqual(getTurnStatus(msg), 'has_errors');
+    });
+
+    it('should return complete if assistant message has stage3 response', () => {
+      const msg = {
+        role: 'assistant',
+        stage3: { response: 'Hello' }
+      };
+      assert.strictEqual(getTurnStatus(msg), 'complete');
+    });
+
+    it('should return in_progress if assistant message has empty stage3 response', () => {
+      const msg = {
+        role: 'assistant',
+        stage3: { response: '' }
+      };
+      assert.strictEqual(getTurnStatus(msg), 'in_progress');
+    });
+  });
+
+  describe('buildConversationOutline', () => {
+    it('should return empty array for empty messages', () => {
+      assert.deepStrictEqual(buildConversationOutline([]), []);
+    });
+
+    it('should build outline for a simple conversation', () => {
+      const messages = [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', stage3: { response: 'hi' } }
+      ];
+      const outline = buildConversationOutline(messages);
+      assert.strictEqual(outline.length, 1);
+      assert.strictEqual(outline[0].turnNumber, 1);
+      assert.strictEqual(outline[0].snippet, 'hello');
+      assert.strictEqual(outline[0].status, 'complete');
+    });
+
+    it('should handle in-progress turns', () => {
+      const messages = [
+        { role: 'user', content: 'hello' }
+      ];
+      const outline = buildConversationOutline(messages, true);
+      assert.strictEqual(outline[0].status, 'in_progress');
+    });
+
+    it('should handle multiple turns', () => {
+      const messages = [
+        { role: 'user', content: 'q1' },
+        { role: 'assistant', stage3: { response: 'a1' } },
+        { role: 'user', content: 'q2' },
+        { role: 'assistant', loading: { stage2: true } }
+      ];
+      const outline = buildConversationOutline(messages);
+      assert.strictEqual(outline.length, 2);
+      assert.strictEqual(outline[0].status, 'complete');
+      assert.strictEqual(outline[1].status, 'in_progress');
+    });
+  });
+});

--- a/frontend/src/lib/logger.js
+++ b/frontend/src/lib/logger.js
@@ -1,0 +1,26 @@
+const isDev = import.meta.env.DEV;
+
+export const logger = {
+    error: (...args) => {
+        if (isDev) {
+            console.error(...args);
+        }
+    },
+    warn: (...args) => {
+        if (isDev) {
+            console.warn(...args);
+        }
+    },
+    log: (...args) => {
+        if (isDev) {
+            console.log(...args);
+        }
+    },
+    info: (...args) => {
+        if (isDev) {
+            console.info(...args);
+        }
+    }
+};
+
+export default logger;

--- a/reproduce_vulnerability.py
+++ b/reproduce_vulnerability.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+# Ensure backend can be imported
+sys.path.append(os.getcwd())
+
+def test_vulnerability():
+    # Ensure JWT_SECRET_KEY is NOT set
+    if "JWT_SECRET_KEY" in os.environ:
+        del os.environ["JWT_SECRET_KEY"]
+
+    # Also ensure APP_ORIGIN is local for the test (it is by default in this env)
+    os.environ["RENDER"] = ""
+    os.environ["REPLIT_ID"] = ""
+
+    try:
+        from backend import auth
+        expected_insecure_key = "dev_secret_key_change_in_production"
+        if auth.SECRET_KEY == expected_insecure_key:
+            print(f"VULNERABILITY CONFIRMED: SECRET_KEY is set to '{auth.SECRET_KEY}' when JWT_SECRET_KEY is missing.")
+            return True
+        else:
+            print(f"VULNERABILITY NOT FOUND: SECRET_KEY is '{auth.SECRET_KEY}'")
+            return False
+    except RuntimeError as e:
+        print(f"VULNERABILITY FIXED: Application raised RuntimeError as expected: {e}")
+        return False
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return False
+
+if __name__ == "__main__":
+    if test_vulnerability():
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/reproduce_vulnerability.py
+++ b/reproduce_vulnerability.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+# Ensure backend can be imported
+sys.path.append(os.getcwd())
+
+def test_vulnerability():
+    # Ensure JWT_SECRET_KEY is NOT set
+    if "JWT_SECRET_KEY" in os.environ:
+        del os.environ["JWT_SECRET_KEY"]
+
+    # Also ensure APP_ORIGIN is local for the test (it is by default in this env)
+    os.environ["RENDER"] = ""
+    os.environ["REPLIT_ID"] = ""
+
+    try:
+        from backend import auth
+        expected_insecure_key = "dev_secret_key_change_in_production"
+        if auth.SECRET_KEY == expected_insecure_key:
+            print("VULNERABILITY CONFIRMED: Insecure fallback key is being used.")
+            return True
+        else:
+            print("VULNERABILITY NOT FOUND: Application did not use the insecure fallback key.")
+            return False
+    except RuntimeError as e:
+        print(f"VULNERABILITY FIXED: Application raised RuntimeError as expected: {e}")
+        return False
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return False
+
+if __name__ == "__main__":
+    if test_vulnerability():
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/scripts/benchmark_mock_delete.py
+++ b/scripts/benchmark_mock_delete.py
@@ -1,0 +1,130 @@
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+from sqlalchemy import select, delete
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+# Mocking the models for the benchmark using SQLAlchemy DeclarativeBase
+class Base(DeclarativeBase):
+    pass
+
+class DocumentModel(Base):
+    __tablename__ = "documents"
+    id: Mapped[str] = mapped_column(primary_key=True)
+    conversation_id: Mapped[str] = mapped_column()
+    user_id: Mapped[str] = mapped_column()
+
+class DocumentChunkModel(Base):
+    __tablename__ = "document_chunks"
+    id: Mapped[str] = mapped_column(primary_key=True)
+    document_id: Mapped[str] = mapped_column()
+    conversation_id: Mapped[str] = mapped_column()
+    user_id: Mapped[str] = mapped_column()
+
+LATENCY = 0.01  # 10ms simulated latency per DB roundtrip
+
+async def simulated_delay(*args, **kwargs):
+    await asyncio.sleep(LATENCY)
+
+async def mock_execute(statement, *args, **kwargs):
+    await asyncio.sleep(LATENCY)
+    mock_result = MagicMock()
+    # If it's a select, return a mock object
+    if "SELECT" in str(statement).upper():
+        mock_result.scalar_one_or_none.return_value = MagicMock()
+    # If it's a delete, return rowcount = 1
+    elif "DELETE" in str(statement).upper():
+        mock_result.rowcount = 1
+    return mock_result
+
+async def current_logic(conversation_id, document_id, user_id, session):
+    # Roundtrip 1: Select
+    result = await session.execute(
+        select(DocumentModel)
+        .where(
+            DocumentModel.id == document_id,
+            DocumentModel.conversation_id == conversation_id,
+            DocumentModel.user_id == user_id
+        )
+    )
+    doc = result.scalar_one_or_none()
+    if not doc:
+        raise ValueError("Unauthorized or not found")
+
+    # Roundtrip 2: Delete Chunks
+    await session.execute(
+        delete(DocumentChunkModel)
+        .where(
+            DocumentChunkModel.document_id == document_id,
+            DocumentChunkModel.conversation_id == conversation_id,
+            DocumentChunkModel.user_id == user_id
+        )
+    )
+
+    # Roundtrip 3: Delete Document
+    await session.delete(doc)
+    # Roundtrip 4: Commit
+    await session.commit()
+
+async def optimized_logic(conversation_id, document_id, user_id, session):
+    # Roundtrip 1: Delete Chunks
+    await session.execute(
+        delete(DocumentChunkModel)
+        .where(
+            DocumentChunkModel.document_id == document_id,
+            DocumentChunkModel.conversation_id == conversation_id,
+            DocumentChunkModel.user_id == user_id
+        )
+    )
+
+    # Roundtrip 2: Delete Document with rowcount check
+    result = await session.execute(
+        delete(DocumentModel)
+        .where(
+            DocumentModel.id == document_id,
+            DocumentModel.conversation_id == conversation_id,
+            DocumentModel.user_id == user_id
+        )
+    )
+
+    if result.rowcount == 0:
+        await session.rollback()
+        raise ValueError("Unauthorized or not found")
+
+    # Roundtrip 3: Commit
+    await session.commit()
+
+async def run_benchmark():
+    num_iterations = 50
+    print(f"Benchmarking with {LATENCY*1000}ms simulated latency...")
+
+    # Benchmark Current
+    start = time.perf_counter()
+    for _ in range(num_iterations):
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=mock_execute)
+        session.commit = AsyncMock(side_effect=simulated_delay)
+        session.delete = AsyncMock(side_effect=simulated_delay)
+        await current_logic("conv", "doc", "user", session)
+    end = time.perf_counter()
+    avg_current = (end - start) / num_iterations
+    print(f"Current logic avg time: {avg_current:.4f}s")
+
+    # Benchmark Optimized
+    start = time.perf_counter()
+    for _ in range(num_iterations):
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=mock_execute)
+        session.commit = AsyncMock(side_effect=simulated_delay)
+        await optimized_logic("conv", "doc", "user", session)
+    end = time.perf_counter()
+    avg_optimized = (end - start) / num_iterations
+    print(f"Optimized logic avg time: {avg_optimized:.4f}s")
+
+    improvement = (avg_current - avg_optimized) / avg_current * 100
+    print(f"Improvement: {improvement:.2f}%")
+    print(f"Roundtrips saved: {round((avg_current - avg_optimized) / LATENCY)}")
+
+if __name__ == "__main__":
+    asyncio.run(run_benchmark())

--- a/scripts/benchmark_storage_delete.py
+++ b/scripts/benchmark_storage_delete.py
@@ -1,0 +1,94 @@
+import time
+import uuid
+import os
+import json
+from typing import Dict, Any, List
+
+# Mocking the bundle for benchmarking
+def create_mock_bundle(num_docs: int, chunks_per_doc: int, user_id: str):
+    documents = []
+    chunks = []
+    for i in range(num_docs):
+        doc_id = f"doc_{i}"
+        documents.append({
+            "id": doc_id,
+            "user_id": user_id,
+            "filename": f"file_{i}.pdf",
+            "size_bytes": 1024,
+            "created_at": "2023-01-01T00:00:00"
+        })
+        for j in range(chunks_per_doc):
+            chunks.append({
+                "id": str(uuid.uuid4()),
+                "document_id": doc_id,
+                "user_id": user_id,
+                "content": "some content " * 10
+            })
+    return {"documents": documents, "chunks": chunks}
+
+def original_file_delete_document_logic(bundle, document_id, user_id):
+    documents = bundle.get("documents", [])
+    chunks = bundle.get("chunks", [])
+    new_documents = [doc for doc in documents if not (doc.get("id") == document_id and doc.get("user_id") == user_id)]
+    if len(new_documents) == len(documents):
+        raise ValueError("Unauthorized or not found")
+    bundle["documents"] = new_documents
+    bundle["chunks"] = [chunk for chunk in chunks if chunk.get("document_id") != document_id]
+    return bundle
+
+def optimized_file_delete_document_logic(bundle, document_id, user_id):
+    documents = bundle.get("documents", [])
+
+    found_idx = -1
+    for i, doc in enumerate(documents):
+        if doc.get("id") == document_id and doc.get("user_id") == user_id:
+            found_idx = i
+            break
+
+    if found_idx == -1:
+        raise ValueError("Unauthorized or not found")
+
+    documents.pop(found_idx)
+    # bundle["chunks"] remains the same logic as it needs to filter ALL chunks
+    chunks = bundle.get("chunks", [])
+    bundle["chunks"] = [chunk for chunk in chunks if chunk.get("document_id") != document_id]
+    return bundle
+
+def run_bench(name, func, bundle, doc_to_delete, user_id, iterations=1000):
+    start = time.perf_counter()
+    for _ in range(iterations):
+        # We need to copy because the logic modifies in-place
+        test_bundle = {
+            "documents": list(bundle["documents"]),
+            "chunks": list(bundle["chunks"])
+        }
+        func(test_bundle, doc_to_delete, user_id)
+    end = time.perf_counter()
+    avg_time = (end - start) / iterations
+    print(f"{name}: {avg_time:.8f} seconds per call")
+    return avg_time
+
+def benchmark():
+    num_docs = 1000
+    chunks_per_doc = 10
+    user_id = "user123"
+
+    bundle = create_mock_bundle(num_docs, chunks_per_doc, user_id)
+
+    print(f"Benchmarking with {num_docs} documents and {num_docs * chunks_per_doc} chunks total.")
+
+    scenarios = [
+        ("Near start", "doc_0"),
+        ("Middle", f"doc_{num_docs // 2}"),
+        ("Near end", f"doc_{num_docs - 1}")
+    ]
+
+    for label, doc_id in scenarios:
+        print(f"\nScenario: {label}")
+        orig_time = run_bench("  Original", original_file_delete_document_logic, bundle, doc_id, user_id)
+        opt_time = run_bench("  Optimized", optimized_file_delete_document_logic, bundle, doc_id, user_id)
+        improvement = (orig_time - opt_time) / orig_time * 100
+        print(f"  Improvement: {improvement:.2f}%")
+
+if __name__ == "__main__":
+    benchmark()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,10 @@
 import pytest
 import pytest_asyncio
 import os
+
+# Set dummy secret key for tests before importing backend modules
+os.environ.setdefault("JWT_SECRET_KEY", "test_only_dummy_secret_key_for_unit_tests")
+
 from httpx import AsyncClient, ASGITransport
 from backend.main import app
 

--- a/tests/test_council.py
+++ b/tests/test_council.py
@@ -49,3 +49,102 @@ async def test_stage3_synthesis():
             full_response += token
         
         assert full_response == "Final Answer"
+
+
+def test_parse_confidence_from_text():
+    assert council.parse_confidence_from_text("FINAL RANKING:\n1. Response A\nCONFIDENCE: 82") == 82
+    assert council.parse_confidence_from_text("confidence: 150") == 100
+    assert council.parse_confidence_from_text("No explicit confidence provided") is None
+
+
+def test_calculate_aggregate_rankings_uses_ballot_weights():
+    stage2_results = [
+        {
+            "model": "judge-a",
+            "ranking": "FINAL RANKING:\n1. Response A\n2. Response B",
+            "parsed_ranking": ["Response A", "Response B"],
+            "ballot_weight": 1.5,
+        },
+        {
+            "model": "judge-b",
+            "ranking": "FINAL RANKING:\n1. Response B\n2. Response A",
+            "parsed_ranking": ["Response B", "Response A"],
+            "ballot_weight": 0.5,
+        },
+    ]
+    label_to_model = {"Response A": "model-a", "Response B": "model-b"}
+
+    aggregate = council.calculate_aggregate_rankings(stage2_results, label_to_model)
+
+    assert aggregate[0]["model"] == "model-a"
+    assert aggregate[0]["average_rank"] == 1.25
+    assert aggregate[0]["rankings_count"] == 2
+    assert aggregate[0]["total_weight"] == 2.0
+    assert aggregate[0]["weighted"] is True
+    assert aggregate[1]["model"] == "model-b"
+    assert aggregate[1]["average_rank"] == 1.75
+
+
+def test_build_model_weight_profile_tracks_prior_rounds():
+    conversation_messages = [
+        {
+            "role": "assistant",
+            "metadata": {
+                "responded_council_models": ["model-a", "model-b"],
+                "aggregate_rankings": [
+                    {"model": "model-a", "average_rank": 1.0},
+                    {"model": "model-b", "average_rank": 2.0},
+                ],
+            },
+        },
+    ]
+
+    profiles = council.build_model_weight_profile(
+        conversation_messages,
+        ["model-a", "model-b", "model-c"],
+    )
+
+    assert profiles["model-a"]["rounds_observed"] == 1
+    assert profiles["model-a"]["average_performance"] == 1.0
+    assert profiles["model-a"]["dynamic_weight"] == 1.5
+    assert profiles["model-b"]["average_performance"] == 0.0
+    assert profiles["model-b"]["dynamic_weight"] == 0.5
+    assert profiles["model-c"]["rounds_observed"] == 0
+    assert profiles["model-c"]["dynamic_weight"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_stage2_collect_rankings_heterogeneous_adds_confidence_and_weights():
+    mocked_responses = {
+        "model-a": {
+            "content": "Analysis\nFINAL RANKING:\n1. Response A\n2. Response B\nCONFIDENCE: 80"
+        },
+        "model-b": {
+            "content": "Analysis\nFINAL RANKING:\n1. Response B\n2. Response A\nCONFIDENCE: 60"
+        },
+    }
+
+    with patch("backend.council.query_models_parallel", new_callable=AsyncMock) as mock_parallel:
+        mock_parallel.return_value = mocked_responses
+
+        stage2_results, label_to_model = await council.stage2_collect_rankings(
+            "Which answer is best?",
+            [
+                {"model": "model-a", "response": "Answer A"},
+                {"model": "model-b", "response": "Answer B"},
+            ],
+            council_models=["model-a", "model-b"],
+            framework="heterogeneous",
+            model_profiles={
+                "model-a": {"dynamic_weight": 1.4},
+                "model-b": {"dynamic_weight": 0.8},
+            },
+        )
+
+    assert label_to_model == {"Response A": "model-a", "Response B": "model-b"}
+    assert stage2_results[0]["confidence_score"] == 80
+    assert stage2_results[0]["historical_weight"] == 1.4
+    assert stage2_results[0]["ballot_weight"] == 1.12
+    assert stage2_results[1]["confidence_score"] == 60
+    assert stage2_results[1]["historical_weight"] == 0.8
+    assert stage2_results[1]["ballot_weight"] == 0.48

--- a/tests/test_db_ssl.py
+++ b/tests/test_db_ssl.py
@@ -31,17 +31,33 @@ def test_verify_ca_is_secure_cert_only():
     assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is False
 
-def test_require_is_still_lenient():
+def test_require_is_secure():
     """
-    Asserts that sslmode=require remains lenient (CERT_NONE) for compatibility.
+    Asserts that sslmode=require is now secure (CERT_REQUIRED) but without hostname check.
     """
     query_params = {"sslmode": "require"}
     connect_args, updated_params = configure_ssl_context(query_params)
 
     ctx = connect_args.get("ssl")
     assert ctx is not None
-    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is False
+
+def test_sslrootcert_loading():
+    """
+    Asserts that sslrootcert is correctly handled and loaded into the context.
+    """
+    from unittest.mock import patch, MagicMock
+
+    query_params = {"sslmode": "verify-ca", "sslrootcert": "/path/to/ca.crt"}
+
+    with patch("ssl.SSLContext.load_verify_locations") as mock_load:
+        connect_args, updated_params = configure_ssl_context(query_params)
+
+        ctx = connect_args.get("ssl")
+        assert ctx is not None
+        mock_load.assert_called_once_with(cafile="/path/to/ca.crt")
+        assert "sslrootcert" not in updated_params
 
 def test_no_sslmode():
     """

--- a/tests/test_db_ssl.py
+++ b/tests/test_db_ssl.py
@@ -31,17 +31,39 @@ def test_verify_ca_is_secure_cert_only():
     assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is False
 
-def test_require_is_still_lenient():
+def test_require_is_now_secure():
     """
-    Asserts that sslmode=require remains lenient (CERT_NONE) for compatibility.
+    Asserts that sslmode=require now enforces certificate validation.
     """
     query_params = {"sslmode": "require"}
     connect_args, updated_params = configure_ssl_context(query_params)
 
     ctx = connect_args.get("ssl")
     assert ctx is not None
-    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is False
+
+def test_sslrootcert_is_processed(tmp_path):
+    """
+    Asserts that sslrootcert is correctly processed and loaded into the SSL context.
+    """
+    # Create a dummy root cert file
+    cert_file = tmp_path / "root.crt"
+    cert_file.write_text("dummy certificate content")
+
+    query_params = {"sslmode": "require", "sslrootcert": str(cert_file)}
+
+    # We need to mock load_verify_locations because it will fail with dummy content
+    import unittest.mock as mock
+    with mock.patch("ssl.SSLContext.load_verify_locations") as mock_load:
+        connect_args, updated_params = configure_ssl_context(query_params)
+
+        ctx = connect_args.get("ssl")
+        assert ctx is not None
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        mock_load.assert_called_once_with(cafile=str(cert_file))
+
+    assert "sslrootcert" not in updated_params
 
 def test_no_sslmode():
     """

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -5,6 +5,46 @@ import pytest
 from backend import documents, retrieval, storage, config
 
 
+@pytest.mark.parametrize("filename, content_type, expected", [
+    ("test.pdf", "application/pdf", True),
+    ("test.PDF", "application/pdf", True),
+    ("test.pdf", "APPLICATION/PDF", True),
+    ("test.pdf", None, True),
+    (None, "application/pdf", True),
+    ("test.txt", "text/plain", False),
+    ("test.pdf.txt", "text/plain", False),
+    (None, None, False),
+    ("", "", False),
+    ("test.pdf", "text/plain", True), # filename wins
+    ("test.txt", "application/pdf", True), # content_type wins
+])
+def test_is_pdf_file(filename, content_type, expected):
+    assert documents.is_pdf_file(filename, content_type) == expected
+
+
+@pytest.mark.parametrize("header, expected", [
+    (b"%PDF-1.4", True),
+    (b"%PDF-1.7", True),
+    (b"%PDF-2.0", True),
+    (b"NOT A PDF", False),
+    (b"", False),
+    (b" %PDF-1.4", False), # Must start with %PDF-
+])
+def test_validate_pdf_header(header, expected):
+    assert documents.validate_pdf_header(header) == expected
+
+
+@pytest.mark.parametrize("text, expected", [
+    ("  hello   world  ", "hello world"),
+    ("\nhello\tworld\r", "hello world"),
+    ("multiple    spaces", "multiple spaces"),
+    ("", ""),
+    ("   ", ""),
+])
+def test_normalize_text(text, expected):
+    assert documents.normalize_text(text) == expected
+
+
 def test_chunk_pages_overlap():
     text = "one two three four five six seven eight nine ten"
     chunks = documents.chunk_pages([text], chunk_words=4, overlap_words=1)

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -5,6 +5,34 @@ import pytest
 from backend import documents, retrieval, storage, config
 
 
+@pytest.mark.parametrize("text,expected", [
+    ("hello world", "hello world"),
+    ("hello   world", "hello world"),
+    ("hello\tworld", "hello world"),
+    ("hello\nworld", "hello world"),
+    ("  hello \n \t world  ", "hello world"),
+    ("", ""),
+    ("   \n\t  ", ""),
+    ("multiple   spaces   between   words", "multiple spaces between words"),
+])
+def test_normalize_text(text, expected):
+    assert documents.normalize_text(text) == expected
+
+
+@pytest.mark.parametrize("header,expected", [
+    (b"%PDF-1.4", True),
+    (b"%PDF-1.7", True),
+    (b"%PDF-2.0", True),
+    (b"PDF-1.4", False),
+    (b" %PDF-1.4", False),
+    (b"something %PDF-1.4", False),
+    (b"", False),
+    (b"random bytes", False),
+])
+def test_validate_pdf_header(header, expected):
+    assert documents.validate_pdf_header(header) == expected
+
+
 def test_chunk_pages_overlap():
     text = "one two three four five six seven eight nine ten"
     chunks = documents.chunk_pages([text], chunk_words=4, overlap_words=1)

--- a/tests/test_file_delete_document.py
+++ b/tests/test_file_delete_document.py
@@ -1,0 +1,74 @@
+import asyncio
+import os
+import sys
+import json
+import uuid
+
+# Add project root to sys.path to import backend modules
+sys.path.append(os.getcwd())
+
+from backend import storage
+
+async def test_file_delete_document():
+    print("Testing file_delete_document functionality...")
+
+    # Ensure we are using file storage
+    if os.getenv("DATABASE_URL"):
+        print("DATABASE_URL is set. Temporarily unsetting it to test file storage.")
+        db_url = os.environ.pop("DATABASE_URL")
+    else:
+        db_url = None
+
+    conversation_id = str(uuid.uuid4())
+    user_id = "test_user_123"
+
+    try:
+        # 1. Create a conversation
+        await storage.create_conversation(conversation_id, user_id)
+
+        # 2. Add a document (manually via storage.file_create_document)
+        filename = "test_doc.pdf"
+        size_bytes = 100
+        doc = storage.file_create_document(conversation_id, user_id, filename, size_bytes)
+        doc_id = doc["id"]
+        print(f"Created document: {doc_id}")
+
+        # Verify document exists in bundle
+        bundle = storage.load_documents_bundle(conversation_id)
+        assert any(d["id"] == doc_id for d in bundle["documents"]), "Document not found in bundle after creation"
+        print("Document confirmed in bundle.")
+
+        # 3. Delete the document
+        storage.file_delete_document(conversation_id, doc_id, user_id)
+        print(f"Deleted document: {doc_id}")
+
+        # 4. Verify document is gone
+        bundle = storage.load_documents_bundle(conversation_id)
+        assert not any(d["id"] == doc_id for d in bundle["documents"]), "Document still in bundle after deletion"
+        print("SUCCESS: Document removed from bundle.")
+
+        # 5. Test unauthorized/not found
+        try:
+            storage.file_delete_document(conversation_id, "non_existent_id", user_id)
+            print("FAILURE: Expected ValueError for non-existent document, but none was raised.")
+            sys.exit(1)
+        except ValueError as e:
+            print(f"Correctly caught expected error: {e}")
+
+    finally:
+        # Cleanup
+        if db_url:
+            os.environ["DATABASE_URL"] = db_url
+
+        # Cleanup files if they exist
+        doc_path = storage.get_documents_path(conversation_id)
+        if os.path.exists(doc_path):
+            os.remove(doc_path)
+
+        # Also cleanup conversation file if it exists
+        conv_path = os.path.join("data", "conversations", f"{conversation_id}.json")
+        if os.path.exists(conv_path):
+            os.remove(conv_path)
+
+if __name__ == "__main__":
+    asyncio.run(test_file_delete_document())

--- a/tests/test_ranking_parser.py
+++ b/tests/test_ranking_parser.py
@@ -68,3 +68,42 @@ def test_case_sensitivity():
 def test_varied_whitespace():
     text = "FINAL RANKING: 1.Response A, 2.  Response B"
     assert parse_ranking_from_text(text) == ["Response A", "Response B"]
+
+def test_missing_colon_in_marker():
+    # If colon is missing, marker "FINAL RANKING:" isn't found, should fallback to whole text search
+    text = """
+    FINAL RANKING
+    1. Response B
+    2. Response A
+    """
+    # Since "FINAL RANKING:" (with colon) is not found, it uses the fallback which finds all Response [A-Z]
+    assert parse_ranking_from_text(text) == ["Response B", "Response A"]
+
+def test_duplicate_responses():
+    # Test that duplicate mentions are preserved in the order they appear
+    text = "FINAL RANKING: 1. Response A, 2. Response A, 3. Response B"
+    assert parse_ranking_from_text(text) == ["Response A", "Response A", "Response B"]
+
+def test_multiple_markers():
+    # Test that the parser starts from the first "FINAL RANKING:" marker
+    text = """
+    FINAL RANKING:
+    1. Response A
+
+    Wait, I changed my mind.
+    FINAL RANKING:
+    1. Response B
+    """
+    # It finds everything after the FIRST "FINAL RANKING:"
+    # numbered_matches will find "1. Response A" and "1. Response B"
+    assert parse_ranking_from_text(text) == ["Response A", "Response B"]
+
+def test_empty_ranking_section():
+    # Ensure the parser returns an empty list if no "Response X" patterns are found after the marker
+    text = "FINAL RANKING: No responses were good enough to rank."
+    assert parse_ranking_from_text(text) == []
+
+def test_lowercase_response_label():
+    # Ensure "response a" is correctly normalized to "Response A"
+    text = "FINAL RANKING: 1. response a, 2. Response B"
+    assert parse_ranking_from_text(text) == ["Response A", "Response B"]

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,43 @@
+from backend.retrieval import _build_context
+
+def test_build_context_empty():
+    assert _build_context([]) == ""
+
+def test_build_context_single():
+    citations = [
+        {
+            "filename": "test.pdf",
+            "page_number": 1,
+            "snippet": "This is a test snippet."
+        }
+    ]
+    expected = (
+        "You have access to the following document excerpts.\n"
+        "Use them to answer the user's question and cite sources as [filename p.#].\n\n"
+        "Source: test.pdf (p. 1)\n"
+        "This is a test snippet."
+    )
+    assert _build_context(citations) == expected
+
+def test_build_context_multiple():
+    citations = [
+        {
+            "filename": "test1.pdf",
+            "page_number": 1,
+            "snippet": "Snippet 1"
+        },
+        {
+            "filename": "test2.pdf",
+            "page_number": 5,
+            "snippet": "Snippet 2"
+        }
+    ]
+    expected = (
+        "You have access to the following document excerpts.\n"
+        "Use them to answer the user's question and cite sources as [filename p.#].\n\n"
+        "Source: test1.pdf (p. 1)\n"
+        "Snippet 1\n\n"
+        "Source: test2.pdf (p. 5)\n"
+        "Snippet 2"
+    )
+    assert _build_context(citations) == expected

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,7 +5,7 @@ from backend.main import CreateConversationRequest, SendMessageRequest
 
 def test_valid_frameworks():
     """Test that all allowed frameworks are accepted."""
-    for framework in ["standard", "six_hats", "debate", "ensemble"]:
+    for framework in ["standard", "six_hats", "debate", "ensemble", "heterogeneous"]:
         req = CreateConversationRequest(framework=framework)
         assert req.framework == framework
 

--- a/tests/verify_db_delete_optimization.py
+++ b/tests/verify_db_delete_optimization.py
@@ -1,0 +1,47 @@
+
+import pytest
+import uuid
+from unittest.mock import AsyncMock, patch, MagicMock
+from backend import storage
+from backend.database import DocumentModel, DocumentChunkModel
+
+@pytest.mark.asyncio
+async def test_db_delete_document_success():
+    # Mock AsyncSessionLocal and its session
+    mock_session = AsyncMock()
+    mock_session_cm = AsyncMock()
+    mock_session_cm.__aenter__.return_value = mock_session
+
+    # Mock delete results
+    mock_result_chunks = MagicMock()
+    mock_result_doc = MagicMock()
+    mock_result_doc.rowcount = 1  # Success
+
+    mock_session.execute.side_effect = [mock_result_chunks, mock_result_doc]
+
+    with patch("backend.storage.AsyncSessionLocal", return_value=mock_session_cm):
+        await storage.db_delete_document("conv1", "doc1", "user1")
+
+    assert mock_session.commit.called
+    assert not mock_session.rollback.called
+
+@pytest.mark.asyncio
+async def test_db_delete_document_unauthorized_or_not_found():
+    # Mock AsyncSessionLocal and its session
+    mock_session = AsyncMock()
+    mock_session_cm = AsyncMock()
+    mock_session_cm.__aenter__.return_value = mock_session
+
+    # Mock delete results
+    mock_result_chunks = MagicMock()
+    mock_result_doc = MagicMock()
+    mock_result_doc.rowcount = 0  # Not found or unauthorized
+
+    mock_session.execute.side_effect = [mock_result_chunks, mock_result_doc]
+
+    with patch("backend.storage.AsyncSessionLocal", return_value=mock_session_cm):
+        with pytest.raises(ValueError, match="Unauthorized or not found"):
+            await storage.db_delete_document("conv1", "doc1", "user1")
+
+    assert mock_session.rollback.called
+    assert not mock_session.commit.called

--- a/tests/verify_live_api.py
+++ b/tests/verify_live_api.py
@@ -6,7 +6,10 @@ import os
 from datetime import datetime, timedelta
 
 # Configuration matched to backend/auth.py
-SECRET_KEY = os.getenv("JWT_SECRET_KEY", "dev_secret_key_change_in_production")
+SECRET_KEY = os.getenv("JWT_SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("JWT_SECRET_KEY environment variable is required for tests.")
+
 ALGORITHM = "HS256"
 API_URL = "http://localhost:8001/api"
 


### PR DESCRIPTION
## Summary

This PR opens the current `feature/start_new` branch against `master`. The branch collects the start-new stream of work: council weighting support, conversation navigation improvements, backend hardening around auth, model error handling, and database SSL, performance cleanup for document deletion and regex compilation, broader tests, and refreshed agent/context docs.

## Issue

The branch addresses a mix of product and operational gaps. Users could not tune heterogeneous council weights, long conversations were harder to navigate, and several backend paths had avoidable security and performance issues. The result was weaker UX for multi-model chats plus unnecessary risk around JWT defaults, model-listing and file-delete error handling, and PostgreSQL SSL verification.

## Root Cause

These gaps came from missing UI and config surfaces, permissive or noisy backend error handling, and a few hot-path implementations that were functional but not hardened. Test coverage also lagged behind behavior in retrieval, document utilities, ranking parsing, and navigator helpers, which made regressions easier to miss.

## Fix

The branch adds heterogeneous council weighting and global jump-to-top conversation navigation in the frontend, introduces a shared frontend logging utility, hardens backend auth, model-list, and database SSL behavior, optimizes document deletion flows and council regex setup, expands unit coverage across retrieval, document, ranking, and navigator code, adds benchmark and repro scripts, restores and updates `AGENTS.md`, and checks in the latest contextual `Info/` docs for the branch.

## Validation

I ran `uv run pytest` and all 132 tests passed.

I ran `cd frontend && npm run build` and the production build succeeded.

Current known warnings: Vite still reports a chunk larger than 500 kB in the frontend build, and `tests/test_openrouter_client_reuse.py` still emits async-mock runtime warnings even though the suite passes.
