### PR TITLE
🧪 Improve robustness and test coverage for conversation exports

### DIFF
--- a/backend/export.py
+++ b/backend/export.py
@@ -11,34 +11,43 @@ def export_to_markdown(conversation: dict) -> str:
     """
     Export conversation to Markdown format.
     """
+    if not isinstance(conversation, dict):
+        conversation = {}
     lines = []
-    lines.append(f"# {conversation.get('title', 'Conversation')}\n\n")
-    lines.append(f"**Date:** {conversation.get('created_at', '')}\n")
-    lines.append(f"**Framework:** {conversation.get('framework', 'Standard')}\n\n")
+    lines.append(f"# {conversation.get('title') or 'Conversation'}\n\n")
+    lines.append(f"**Date:** {conversation.get('created_at') or ''}\n")
+    lines.append(f"**Framework:** {conversation.get('framework') or 'Standard'}\n\n")
 
-    for msg in conversation.get('messages', []):
+    for msg in (conversation.get('messages') or []):
+        if not isinstance(msg, dict):
+            continue
         role = msg.get('role')
         if role == 'user':
-            lines.append(f"## User\n\n{msg.get('content', '')}\n\n")
+            lines.append(f"## User\n\n{msg.get('content') or ''}\n\n")
         elif role == 'assistant':
             lines.append("## LLM Council\n\n")
 
             # Stage 1
-            if msg.get('stage1'):
+            stage1 = msg.get('stage1')
+            if isinstance(stage1, list) and stage1:
                 lines.append("### Stage 1: Individual Responses\n\n")
-                for res in msg['stage1']:
-                    lines.append(f"**{res.get('model', 'Model')}**:\n\n{res.get('response', '')}\n\n")
+                for res in stage1:
+                    if isinstance(res, dict):
+                        lines.append(f"**{res.get('model') or 'Model'}**:\n\n{res.get('response') or ''}\n\n")
 
             # Stage 2
-            if msg.get('stage2'):
+            stage2 = msg.get('stage2')
+            if isinstance(stage2, list) and stage2:
                 lines.append("### Stage 2: Peer Review\n\n")
-                for res in msg['stage2']:
-                    lines.append(f"**{res.get('model', 'Model')}**:\n\n{res.get('ranking', '')}\n\n")
+                for res in stage2:
+                    if isinstance(res, dict):
+                        lines.append(f"**{res.get('model') or 'Model'}**:\n\n{res.get('ranking') or ''}\n\n")
 
             # Stage 3
-            if msg.get('stage3'):
+            stage3 = msg.get('stage3')
+            if isinstance(stage3, dict):
                 lines.append("### Stage 3: Final Synthesis\n\n")
-                lines.append(f"{msg['stage3'].get('response', '')}\n\n")
+                lines.append(f"{stage3.get('response') or ''}\n\n")
 
         lines.append("---\n\n")
 
@@ -72,21 +81,25 @@ def export_to_pdf(conversation: dict) -> bytes:
         # Convert newlines to breaks
         return escaped.replace('\n', '<br/>')
 
+    if not isinstance(conversation, dict):
+        conversation = {}
     # Title
-    story.append(Paragraph(safe_text(conversation.get('title', 'Conversation')), styles["Title"]))
+    story.append(Paragraph(safe_text(conversation.get('title') or 'Conversation'), styles["Title"]))
     story.append(Spacer(1, 12))
 
     # Metadata
-    story.append(Paragraph(f"<b>Date:</b> {safe_text(conversation.get('created_at', ''))}", styles["Normal"]))
-    story.append(Paragraph(f"<b>Framework:</b> {safe_text(conversation.get('framework', 'Standard'))}", styles["Normal"]))
+    story.append(Paragraph(f"<b>Date:</b> {safe_text(conversation.get('created_at') or '')}", styles["Normal"]))
+    story.append(Paragraph(f"<b>Framework:</b> {safe_text(conversation.get('framework') or 'Standard')}", styles["Normal"]))
     story.append(Spacer(1, 24))
 
-    for msg in conversation.get('messages', []):
+    for msg in (conversation.get('messages') or []):
+        if not isinstance(msg, dict):
+            continue
         role = msg.get('role')
 
         if role == 'user':
             story.append(Paragraph("User", styles["UserHeader"]))
-            content = safe_text(msg.get('content', ''))
+            content = safe_text(msg.get('content') or '')
             story.append(Paragraph(content, styles["Normal"]))
             story.append(Spacer(1, 12))
 
@@ -94,29 +107,34 @@ def export_to_pdf(conversation: dict) -> bytes:
             story.append(Paragraph("LLM Council", styles["CouncilHeader"]))
 
             # Stage 1
-            if msg.get('stage1'):
+            stage1 = msg.get('stage1')
+            if isinstance(stage1, list) and stage1:
                 story.append(Paragraph("Stage 1: Individual Responses", styles["StageHeader"]))
-                for res in msg['stage1']:
-                    model = safe_text(res.get('model', 'Model'))
-                    story.append(Paragraph(f"<b>{model}</b>", styles["ModelName"]))
-                    response = safe_text(res.get('response', ''))
-                    story.append(Paragraph(response, styles["NormalSmall"]))
-                    story.append(Spacer(1, 6))
+                for res in stage1:
+                    if isinstance(res, dict):
+                        model = safe_text(res.get('model') or 'Model')
+                        story.append(Paragraph(f"<b>{model}</b>", styles["ModelName"]))
+                        response = safe_text(res.get('response') or '')
+                        story.append(Paragraph(response, styles["NormalSmall"]))
+                        story.append(Spacer(1, 6))
 
             # Stage 2
-            if msg.get('stage2'):
+            stage2 = msg.get('stage2')
+            if isinstance(stage2, list) and stage2:
                 story.append(Paragraph("Stage 2: Peer Review", styles["StageHeader"]))
-                for res in msg['stage2']:
-                    model = safe_text(res.get('model', 'Model'))
-                    story.append(Paragraph(f"<b>{model}</b>", styles["ModelName"]))
-                    ranking = safe_text(res.get('ranking', ''))
-                    story.append(Paragraph(ranking, styles["NormalSmall"]))
-                    story.append(Spacer(1, 6))
+                for res in stage2:
+                    if isinstance(res, dict):
+                        model = safe_text(res.get('model') or 'Model')
+                        story.append(Paragraph(f"<b>{model}</b>", styles["ModelName"]))
+                        ranking = safe_text(res.get('ranking') or '')
+                        story.append(Paragraph(ranking, styles["NormalSmall"]))
+                        story.append(Spacer(1, 6))
 
             # Stage 3
-            if msg.get('stage3'):
+            stage3 = msg.get('stage3')
+            if isinstance(stage3, dict):
                 story.append(Paragraph("Stage 3: Final Synthesis", styles["StageHeader"]))
-                response = safe_text(msg['stage3'].get('response', ''))
+                response = safe_text(stage3.get('response') or '')
                 story.append(Paragraph(response, styles["Normal"]))
 
         story.append(Spacer(1, 12))

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -45,3 +45,86 @@ def test_markdown_export():
     assert "# Test Conversation" in md
     assert "## User" in md
     assert "Hello" in md
+
+def test_export_empty_conversation():
+    """Test exporting an empty conversation dictionary."""
+    conv = {}
+    # Markdown
+    md = export.export_to_markdown(conv)
+    assert "# Conversation" in md
+    # PDF
+    pdf = export.export_to_pdf(conv)
+    assert pdf.startswith(b"%PDF")
+
+def test_export_messages_none():
+    """Test exporting when messages is None."""
+    conv = {"messages": None}
+    # Should not raise TypeError anymore
+    md = export.export_to_markdown(conv)
+    assert "# Conversation" in md
+
+    pdf = export.export_to_pdf(conv)
+    assert pdf.startswith(b"%PDF")
+
+def test_export_missing_message_fields():
+    """Test exporting messages with missing fields."""
+    conv = {
+        "messages": [
+            {"role": "user"}, # missing content
+            {"role": "assistant"}, # missing stages
+            {"role": "invalid"}, # unknown role
+        ]
+    }
+    md = export.export_to_markdown(conv)
+    assert "## User" in md
+
+    pdf = export.export_to_pdf(conv)
+    assert pdf.startswith(b"%PDF")
+
+def test_export_none_stages():
+    """Test assistant messages with None stages."""
+    conv = {
+        "messages": [
+            {
+                "role": "assistant",
+                "stage1": None,
+                "stage2": None,
+                "stage3": None
+            }
+        ]
+    }
+    # Should handle None stages gracefully
+    md = export.export_to_markdown(conv)
+    assert "## LLM Council" in md
+
+    pdf = export.export_to_pdf(conv)
+    assert pdf.startswith(b"%PDF")
+
+def test_export_malformed_stages():
+    """Test assistant messages with malformed stage data (wrong types)."""
+    conv = {
+        "messages": [
+            {
+                "role": "assistant",
+                "stage1": [{"model": None, "response": None}],
+                "stage2": [None],
+                "stage3": "not a dict"
+            }
+        ]
+    }
+    # Should not raise AttributeError or other crashes
+    md = export.export_to_markdown(conv)
+    assert "## LLM Council" in md
+
+    pdf = export.export_to_pdf(conv)
+    assert pdf.startswith(b"%PDF")
+
+def test_export_invalid_input_types():
+    """Test with completely invalid input types."""
+    # Should handle None or non-dict conversation gracefully
+    for invalid_input in [None, [], "not a dict"]:
+        md = export.export_to_markdown(invalid_input)
+        assert "# Conversation" in md
+
+        pdf = export.export_to_pdf(invalid_input)
+        assert pdf.startswith(b"%PDF")


### PR DESCRIPTION
I have improved the reliability and testing of the conversation export functionality. 

### 🎯 What: The testing gap addressed
The previous implementation of `export_to_pdf` and `export_to_markdown` was vulnerable to crashes when encountering malformed conversation data, particularly `None` values where lists or dictionaries were expected. There were also no tests covering these boundary cases.

### 📊 Coverage: What scenarios are now tested
The following scenarios are now covered in `tests/test_export.py`:
- Empty conversation dictionary `{}`.
- Conversation with `messages` set to `None`.
- Messages with missing optional fields (`role`, `content`).
- Assistant messages with `None` or malformed stage data (`stage1`, `stage2`, `stage3`).
- Completely invalid input types (e.g., passing a string or `None` instead of a dictionary to the export functions).

### ✨ Result: The improvement in test coverage
- **Robustness:** The export functions now use defensive checks (e.g., `isinstance` and `or []` patterns) to ensure they never crash on malformed input, instead falling back to sensible defaults.
- **Reliability:** 8 comprehensive tests now ensure that any future changes to the export logic won't re-introduce these vulnerabilities.
- **Maintainability:** The code in `backend/export.py` is cleaner and more standard in its handling of dictionary access.

---
*PR created automatically by Jules for task [17492526673344623467](https://jules.google.com/task/17492526673344623467) started by @ashwathravi*