### PR TITLE
🔒 [security fix] Remove hardcoded development JWT secret

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,7 +1,6 @@
 """Authentication module for Google Sign-In and JWT management."""
 
 import os
-import sys
 import jwt
 import logging
 from typing import Dict, Any, Optional
@@ -20,24 +19,14 @@ logger = logging.getLogger(__name__)
 # Security: Enforce secure key in production
 jwt_secret = os.getenv("JWT_SECRET_KEY")
 
-if jwt_secret:
-    SECRET_KEY = jwt_secret
-else:
-    if APP_ORIGIN == "local":
-        SECRET_KEY = "dev_secret_key_change_in_production"
-        # Log warning (and print to stderr to ensure visibility during startup)
-        logger.warning("JWT_SECRET_KEY is not set. Using insecure default key.")
-        print(
-            "WARNING: JWT_SECRET_KEY is not set. Using insecure default key. "
-            "This is unsafe for production!",
-            file=sys.stderr
-        )
-    else:
-        # In production (Render, Replit, etc.), fail fast if no secret is set
-        raise RuntimeError(
-            f"CRITICAL SECURITY ERROR: JWT_SECRET_KEY is missing in {APP_ORIGIN} environment. "
-            "You must set a secure random string for JWT_SECRET_KEY to start the application."
-        )
+if not jwt_secret:
+    # Fail fast if no secret is set, regardless of environment
+    raise RuntimeError(
+        "CRITICAL SECURITY ERROR: JWT_SECRET_KEY is missing. "
+        "You must set a secure random string for JWT_SECRET_KEY to start the application."
+    )
+
+SECRET_KEY = jwt_secret
 
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "8000:8000"
     environment:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-dev_secret_key_change_in_production}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
     volumes:
       - ./data:/app/data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,11 @@
 import pytest
 import pytest_asyncio
 import os
+
+# Set a dummy secret key for tests BEFORE importing any backend modules
+# that might trigger the RuntimeError.
+os.environ.setdefault("JWT_SECRET_KEY", "test_only_dummy_secret_key_for_unit_tests")
+
 from httpx import AsyncClient, ASGITransport
 from backend.main import app
 

--- a/tests/verify_live_api.py
+++ b/tests/verify_live_api.py
@@ -6,7 +6,9 @@ import os
 from datetime import datetime, timedelta
 
 # Configuration matched to backend/auth.py
-SECRET_KEY = os.getenv("JWT_SECRET_KEY", "dev_secret_key_change_in_production")
+SECRET_KEY = os.getenv("JWT_SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("JWT_SECRET_KEY environment variable is required for this test script.")
 ALGORITHM = "HS256"
 API_URL = "http://localhost:8001/api"
 


### PR DESCRIPTION
This PR addresses a security vulnerability where a hardcoded JWT secret was used as a fallback for local development. The application now fails to start if JWT_SECRET_KEY is not provided in the environment, ensuring secure configuration across all environments. The test suite has been updated to provide a dummy secret during testing.

---
*PR created automatically by Jules for task [5897454945465916888](https://jules.google.com/task/5897454945465916888) started by @ashwathravi*