### PR TITLE
AR-101: Add mixed Design Studio session target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ data/
 frontend/node_modules/
 frontend/dist/
 frontend/.vite/
+.gstack/

--- a/backend/session_context.py
+++ b/backend/session_context.py
@@ -52,7 +52,10 @@ ALLOWED_ARTIFACT_STATUSES = {"draft", "processing", "ready", "failed"}
 DESIGN_TARGETS: Dict[str, str] = {
     "web_app": "Web App",
     "ios_app": "iOS App",
-    "both": "Web + iOS",
+    "mixed": "Mixed Web + iOS",
+}
+DESIGN_TARGET_ALIASES: Dict[str, str] = {
+    "both": "mixed",
 }
 STUDIO_GOALS: Dict[str, str] = {
     "review": "Review",
@@ -103,6 +106,7 @@ def _normalize_string(value: Any) -> Optional[str]:
 def normalize_design_target(value: Optional[str]) -> str:
     if isinstance(value, str):
         normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+        normalized = DESIGN_TARGET_ALIASES.get(normalized, normalized)
         if normalized in ALLOWED_DESIGN_TARGETS:
             return normalized
     return DEFAULT_DESIGN_TARGET

--- a/frontend/src/components/CouncilConfigDialog.jsx
+++ b/frontend/src/components/CouncilConfigDialog.jsx
@@ -171,7 +171,7 @@ const CouncilConfigDialog = ({
       return { ...baseConfig, design_target: 'ios_app' };
     }
     if (template?.id === 'design_cross_platform_studio') {
-      return { ...baseConfig, design_target: 'both' };
+      return { ...baseConfig, design_target: 'mixed' };
     }
 
     return baseConfig;

--- a/frontend/src/lib/designStudioConfig.js
+++ b/frontend/src/lib/designStudioConfig.js
@@ -10,8 +10,8 @@ export const DESIGN_TARGET_OPTIONS = [
     description: 'Native iPhone and iPad design directions.',
   },
   {
-    id: 'both',
-    name: 'Web + iOS',
+    id: 'mixed',
+    name: 'Mixed Web + iOS',
     description: 'Cross-platform direction with shared intent.',
   },
 ];
@@ -58,11 +58,25 @@ export const DEFAULT_DESIGN_STUDIO_CONFIG = {
   approved_direction_id: null,
 };
 
-export const getDesignTargetLabel = (value) =>
-  DESIGN_TARGET_LABELS[value] || DESIGN_TARGET_LABELS[DEFAULT_DESIGN_STUDIO_CONFIG.design_target];
-
 export const getStudioGoalLabel = (value) =>
   STUDIO_GOAL_LABELS[value] || STUDIO_GOAL_LABELS[DEFAULT_DESIGN_STUDIO_CONFIG.studio_goal];
+
+const normalizeDesignTarget = (value) => {
+  if (typeof value !== 'string') {
+    return DEFAULT_DESIGN_STUDIO_CONFIG.design_target;
+  }
+
+  const normalized = value.trim().toLowerCase().replace(/[-\s]+/g, '_');
+  if (normalized === 'both') {
+    return 'mixed';
+  }
+  return DESIGN_TARGET_LABELS[normalized]
+    ? normalized
+    : DEFAULT_DESIGN_STUDIO_CONFIG.design_target;
+};
+
+export const getDesignTargetLabel = (value) =>
+  DESIGN_TARGET_LABELS[normalizeDesignTarget(value)];
 
 export const normalizeSessionConfig = (sessionType, sessionConfig = {}) => {
   if (sessionType !== 'design_studio') {
@@ -75,9 +89,7 @@ export const normalizeSessionConfig = (sessionType, sessionConfig = {}) => {
     : null;
 
   return {
-    design_target: DESIGN_TARGET_LABELS[next.design_target]
-      ? next.design_target
-      : DEFAULT_DESIGN_STUDIO_CONFIG.design_target,
+    design_target: normalizeDesignTarget(next.design_target),
     studio_goal: STUDIO_GOAL_LABELS[next.studio_goal]
       ? next.studio_goal
       : DEFAULT_DESIGN_STUDIO_CONFIG.studio_goal,

--- a/frontend/src/lib/designStudioConfig.test.js
+++ b/frontend/src/lib/designStudioConfig.test.js
@@ -35,22 +35,29 @@ describe('designStudioConfig', () => {
   it('preserves valid design studio values and trims approved direction', () => {
     assert.deepStrictEqual(
       normalizeSessionConfig('design_studio', {
-        design_target: 'both',
+        design_target: 'mixed',
         studio_goal: 'compare',
         approved_direction_id: '  direction-7  ',
       }),
       {
-        design_target: 'both',
+        design_target: 'mixed',
         studio_goal: 'compare',
         approved_direction_id: 'direction-7',
       }
     );
   });
 
+  it('normalizes legacy both target to mixed', () => {
+    assert.strictEqual(
+      normalizeSessionConfig('design_studio', { design_target: 'both' }).design_target,
+      'mixed'
+    );
+  });
+
   it('clears config for non-design sessions', () => {
     assert.deepStrictEqual(
       normalizeSessionConfig('general', {
-        design_target: 'both',
+        design_target: 'mixed',
         studio_goal: 'handoff',
       }),
       {}
@@ -58,7 +65,8 @@ describe('designStudioConfig', () => {
   });
 
   it('returns readable labels', () => {
-    assert.strictEqual(getDesignTargetLabel('both'), 'Web + iOS');
+    assert.strictEqual(getDesignTargetLabel('mixed'), 'Mixed Web + iOS');
+    assert.strictEqual(getDesignTargetLabel('both'), 'Mixed Web + iOS');
     assert.strictEqual(getStudioGoalLabel('handoff'), 'Handoff');
   });
 });

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -309,7 +309,7 @@ async def test_create_conversation_persists_design_studio_session_config(async_c
                 "specialist_template_id": "design_cross_platform_studio",
                 "execution_mode": "disabled",
                 "session_config": {
-                    "design_target": "both",
+                    "design_target": "mixed",
                     "studio_goal": "handoff",
                     "approved_direction_id": None,
                 },
@@ -326,7 +326,7 @@ async def test_create_conversation_persists_design_studio_session_config(async_c
                     "session_type": "design_studio",
                     "specialist_template_id": "design_cross_platform_studio",
                     "session_config": {
-                        "design_target": "both",
+                        "design_target": "mixed",
                         "studio_goal": "handoff",
                     },
                     "council_models": ["openai/gpt-5.2"],
@@ -337,12 +337,12 @@ async def test_create_conversation_persists_design_studio_session_config(async_c
             payload = response.json()
             assert payload["session_type"] == "design_studio"
             assert payload["session_config"] == {
-                "design_target": "both",
+                "design_target": "mixed",
                 "studio_goal": "handoff",
                 "approved_direction_id": None,
             }
             assert mock_create_conversation.await_args.kwargs["session_config"] == {
-                "design_target": "both",
+                "design_target": "mixed",
                 "studio_goal": "handoff",
                 "approved_direction_id": None,
             }
@@ -358,7 +358,7 @@ async def test_send_message_design_studio_includes_session_context(async_client)
         "session_type": "design_studio",
         "specialist_template_id": "design_cross_platform_studio",
         "session_config": {
-            "design_target": "both",
+            "design_target": "mixed",
             "studio_goal": "compare",
             "approved_direction_id": "direction-beta",
         },
@@ -400,7 +400,7 @@ async def test_send_message_design_studio_includes_session_context(async_client)
             assert "SPECIALIST TEMPLATE:" in effective_context
             assert "Cross-Platform Design Studio" in effective_context
             assert "DESIGN STUDIO CONFIG:" in effective_context
-            assert "Target: Web + iOS" in effective_context
+            assert "Target: Mixed Web + iOS" in effective_context
             assert "Goal: Compare" in effective_context
             assert "Approved Direction: direction-beta" in effective_context
             assert "retrieval context" in effective_context

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -94,7 +94,7 @@ async def test_design_studio_session_config_persists_in_file_storage():
         session_type="design_studio",
         specialist_template_id="design_cross_platform_studio",
         session_config={
-            "design_target": "both",
+            "design_target": "mixed",
             "studio_goal": "handoff",
             "approved_direction_id": "  direction-1  ",
         },
@@ -103,7 +103,7 @@ async def test_design_studio_session_config_persists_in_file_storage():
     assert created["session_type"] == "design_studio"
     assert created["specialist_template_id"] == "design_cross_platform_studio"
     assert created["session_config"] == {
-        "design_target": "both",
+        "design_target": "mixed",
         "studio_goal": "handoff",
         "approved_direction_id": "direction-1",
     }

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -92,16 +92,24 @@ def test_design_studio_session_config_is_normalized():
     req = CreateConversationRequest(
         session_type="design_studio",
         session_config={
-            "design_target": "both",
+            "design_target": "mixed",
             "studio_goal": "handoff",
             "approved_direction_id": "  direction-2  ",
         },
     )
     assert req.session_config == {
-        "design_target": "both",
+        "design_target": "mixed",
         "studio_goal": "handoff",
         "approved_direction_id": "direction-2",
     }
+
+def test_design_studio_legacy_both_target_normalizes_to_mixed():
+    """Test that old cross-platform target values stay compatible."""
+    req = CreateConversationRequest(
+        session_type="design_studio",
+        session_config={"design_target": "both", "studio_goal": "compare"},
+    )
+    assert req.session_config["design_target"] == "mixed"
 
 def test_non_design_sessions_clear_session_config():
     """Test that non-design sessions do not retain design studio config."""


### PR DESCRIPTION
## Summary
- Make mixed the canonical Design Studio target for cross-platform web+iOS sessions.
- Keep legacy both configs compatible by normalizing them to mixed.
- Update frontend setup UI/template defaults and backend session context labels.

## Validation
- node --test frontend/src/lib/designStudioConfig.test.js
- uv run pytest tests/test_validation.py tests/test_storage.py tests/test_api.py -q
- uv run pytest -q, 181 passed with 4 existing warnings in test_openrouter_client_reuse
- cd frontend && npm run test, 23 passed
- cd frontend && npm run lint
- cd frontend && npm run build, passed with existing chunk-size warning
- Browser QA: selected Design Studio, Mixed Web + iOS, Compare, and verified the created conversation persisted session_config.design_target = mixed and studio_goal = compare with no console errors.

## Review/Security
- Pre-landing review against feature/start_new: no actionable findings.
- Focused diff security pass: no secrets, shell execution, unsafe HTML rendering, or LLM trust-boundary writes introduced.