### PR TITLE
AR-102: Render Design Studio workspace states

### DIFF
--- a/frontend/src/components/CouncilMessageBlock.jsx
+++ b/frontend/src/components/CouncilMessageBlock.jsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { AlertTriangle, Trophy, Crown, BrainCircuit, CheckCircle2, FileImage, GitCompareArrows, PauseCircle, RefreshCw, RotateCcw, Wrench, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { buildDesignStudioWorkspaceView, formatDesignStudioScore } from "@/lib/designStudioWorkspace";
 import VisualReviewPanel from './VisualReviewPanel';
 
 // ⚡ Bolt: Memoize markdown rendering to prevent re-parsing on every parent re-render
@@ -459,6 +460,161 @@ const DesignStudioHandoffPanel = memo(({ handoff }) => {
 HandoffSectionContent.displayName = 'HandoffSectionContent';
 DesignStudioHandoffPanel.displayName = 'DesignStudioHandoffPanel';
 
+const designWorkspaceStatusCopy = {
+  empty: 'Waiting for candidate directions',
+  single: 'One viable direction',
+  pending: 'Comparison pending',
+  complete: 'Comparison complete',
+};
+
+const DesignStudioWorkspacePanel = memo(({ designStudio, stage1Errors }) => {
+  const workspace = useMemo(
+    () => buildDesignStudioWorkspaceView(designStudio, stage1Errors),
+    [designStudio, stage1Errors]
+  );
+
+  if (!designStudio) return null;
+
+  const selectedLabel = workspace.selectedCard?.label || workspace.selectedDirectionId || 'No leading direction';
+
+  return (
+    <div className="mb-5 overflow-hidden rounded-xl border border-violet-500/20 bg-background">
+      <div className="border-b bg-muted/40 px-4 py-3">
+        <div className="flex items-start justify-between gap-3 flex-wrap">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <GitCompareArrows className="h-4 w-4 text-violet-600 dark:text-violet-300" />
+              Design Studio workspace
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Candidate directions, comparison status, and current selection.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge variant="secondary" className="text-xs">
+              {designWorkspaceStatusCopy[workspace.status] || workspace.comparisonStatus}
+            </Badge>
+            <Badge variant="outline" className="text-xs">
+              {workspace.candidateCards.length} variants
+            </Badge>
+            {workspace.selectedCard && (
+              <Badge variant="outline" className="text-xs">
+                Leading: {selectedLabel}
+              </Badge>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-4 p-4">
+        {workspace.hasPartialFailures && (
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-900 dark:text-amber-100">
+            <div className="mb-2 flex items-center gap-2 font-semibold">
+              <AlertTriangle className="h-4 w-4" />
+              Partial run
+            </div>
+            <div className="space-y-1">
+              {workspace.failedVariants.map((failure, index) => (
+                <div key={`${failure.model}-${index}`}>
+                  <span className="font-medium">{failure.model}:</span> {failure.error}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {workspace.status === 'empty' ? (
+          <div className="rounded-lg border border-dashed bg-muted/20 p-4 text-sm text-muted-foreground">
+            No candidate directions have arrived yet.
+          </div>
+        ) : (
+          <>
+            <div className="text-sm text-muted-foreground">
+              {workspace.hasComparison
+                ? workspace.status === 'complete'
+                  ? 'Aggregate scoring is available across the viable directions.'
+                  : 'Multiple viable directions are available; aggregate comparison has not completed yet.'
+                : 'Waiting for another viable direction before aggregate comparison.'}
+            </div>
+
+            <div className="grid gap-3 lg:grid-cols-2">
+              {workspace.candidateCards.map((card) => (
+                <div
+                  key={card.id}
+                  className={cn(
+                    'rounded-lg border bg-card/60 p-4',
+                    card.isSelected && 'border-emerald-500/40 bg-emerald-500/10'
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <h3 className="text-sm font-semibold">{card.label}</h3>
+                        {card.isSelected && (
+                          <Badge className="gap-1 border border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300">
+                            <Trophy className="h-3 w-3" />
+                            Leading
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        {card.sourceModel}
+                      </div>
+                    </div>
+                    {card.rank && (
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-bold">
+                        {card.rank}
+                      </div>
+                    )}
+                  </div>
+
+                  {card.summary ? (
+                    <p className="mt-3 text-sm text-foreground/85">{card.summary}</p>
+                  ) : (
+                    <p className="mt-3 text-sm text-muted-foreground">No summary captured for this variant.</p>
+                  )}
+
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    <Badge variant="outline">Avg rank {formatDesignStudioScore(card.averageRank)}</Badge>
+                    <Badge variant="outline">Score {formatDesignStudioScore(card.overallScore)}/5</Badge>
+                    {card.rankingsCount !== null && (
+                      <Badge variant="outline">{card.rankingsCount} evaluations</Badge>
+                    )}
+                    {card.totalWeight !== null && (
+                      <Badge variant="outline">Weight {formatDesignStudioScore(card.totalWeight)}</Badge>
+                    )}
+                  </div>
+
+                  {card.criteria.length > 0 && (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {card.criteria.slice(0, 4).map((criterion, index) => {
+                        const criterionLabel = criterion.label || criterion.key || 'Criterion';
+                        return (
+                          <div
+                            key={`${card.id}-${criterionLabel}-${index}`}
+                            className={cn(
+                              'rounded-full border px-2.5 py-1 text-xs font-medium',
+                              rubricToneClass(criterion.average_score)
+                            )}
+                          >
+                            {criterionLabel} {formatDesignStudioScore(criterion.average_score)}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+});
+
+DesignStudioWorkspacePanel.displayName = 'DesignStudioWorkspacePanel';
+
 const formatModelList = (models) => {
   if (!Array.isArray(models) || models.length === 0) {
     return 'None';
@@ -631,11 +787,13 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
     : EMPTY_LIST;
   const hasVisualReviewTab = metadata?.session_type === 'visual_review' && visualArtifacts.length > 0;
   const hasExecutionTab = Boolean(executionReport);
+  const designStudioMetadata = metadata?.session_type === 'design_studio'
+    ? metadata?.design_studio
+    : null;
   const designStudioHandoff = (
-    metadata?.session_type === 'design_studio' &&
-    metadata?.design_studio?.handoff?.status === 'ready'
+    designStudioMetadata?.handoff?.status === 'ready'
   )
-    ? metadata.design_studio.handoff
+    ? designStudioMetadata.handoff
     : null;
 
   const requestedCouncilModels = Array.isArray(metadata?.requested_council_models)
@@ -860,22 +1018,26 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
                       </Button>
                     </div>
                   )}
+                  <DesignStudioWorkspacePanel designStudio={designStudioMetadata} stage1Errors={stage1Errors} />
                   <DesignStudioHandoffPanel handoff={designStudioHandoff} />
                   <MarkdownContent content={stage3.response} />
                   {loading?.stage3 && <span className="inline-block w-2 h-4 bg-primary animate-pulse ml-1" />}
                 </>
               ) : (
-                <div className="flex flex-col items-center justify-center p-8 text-muted-foreground gap-3">
-                  <BrainCircuit className="h-8 w-8 animate-pulse text-primary/50" />
-                  <p>The Council is deliberating...</p>
-                  <div className="flex gap-2 text-xs">
-                    <span className={cn('transition-opacity', loading?.stage1 ? 'opacity-100 font-medium text-foreground' : 'opacity-50')}>Collecting Thoughts</span>
-                    <span>→</span>
-                    <span className={cn('transition-opacity', loading?.stage2 ? 'opacity-100 font-medium text-foreground' : 'opacity-50')}>Debating</span>
-                    <span>→</span>
-                    <span className={cn('transition-opacity', loading?.stage3 ? 'opacity-100 font-medium text-foreground' : 'opacity-50')}>Synthesizing</span>
+                <>
+                  <DesignStudioWorkspacePanel designStudio={designStudioMetadata} stage1Errors={stage1Errors} />
+                  <div className="flex flex-col items-center justify-center p-8 text-muted-foreground gap-3">
+                    <BrainCircuit className="h-8 w-8 animate-pulse text-primary/50" />
+                    <p>The Council is deliberating...</p>
+                    <div className="flex gap-2 text-xs">
+                      <span className={cn('transition-opacity', loading?.stage1 ? 'opacity-100 font-medium text-foreground' : 'opacity-50')}>Collecting Thoughts</span>
+                      <span>→</span>
+                      <span className={cn('transition-opacity', loading?.stage2 ? 'opacity-100 font-medium text-foreground' : 'opacity-50')}>Debating</span>
+                      <span>→</span>
+                      <span className={cn('transition-opacity', loading?.stage3 ? 'opacity-100 font-medium text-foreground' : 'opacity-50')}>Synthesizing</span>
+                    </div>
                   </div>
-                </div>
+                </>
               )}
             </div>
           </TabsContent>

--- a/frontend/src/lib/designStudioWorkspace.js
+++ b/frontend/src/lib/designStudioWorkspace.js
@@ -1,0 +1,99 @@
+const EMPTY_LIST = [];
+
+const asArray = (value) => (Array.isArray(value) ? value : EMPTY_LIST);
+
+const cleanString = (value, fallback = '') => (
+  typeof value === 'string' && value.trim() ? value.trim() : fallback
+);
+
+const toMapByDirection = (items) => {
+  const map = new Map();
+  asArray(items).forEach((item) => {
+    const directionId = cleanString(item?.direction_id);
+    if (directionId) {
+      map.set(directionId, item);
+    }
+  });
+  return map;
+};
+
+export const formatDesignStudioScore = (value) => (
+  typeof value === 'number' && Number.isFinite(value)
+    ? value.toFixed(1).replace(/\.0$/, '')
+    : 'n/a'
+);
+
+export const buildDesignStudioWorkspaceView = (designStudio = {}, stage1Errors = []) => {
+  const candidates = asArray(designStudio?.candidate_directions)
+    .filter((candidate) => candidate && typeof candidate === 'object');
+  const comparison = designStudio?.comparison && typeof designStudio.comparison === 'object'
+    ? designStudio.comparison
+    : {};
+  const rankedDirections = asArray(comparison.ranked_directions);
+  const rubricSummaries = asArray(comparison.rubric_summaries);
+  const rankingByDirection = toMapByDirection(rankedDirections);
+  const rubricByDirection = toMapByDirection(rubricSummaries);
+  const firstRankedDirectionId = cleanString(rankedDirections[0]?.direction_id);
+  const firstCandidateId = cleanString(candidates[0]?.id);
+  const selectedDirectionId = cleanString(
+    designStudio?.selected_direction_id,
+    firstRankedDirectionId || firstCandidateId
+  );
+
+  const failedVariants = asArray(stage1Errors)
+    .filter((item) => item && typeof item === 'object')
+    .map((item) => ({
+      model: cleanString(item.model, 'Unknown model'),
+      error: cleanString(item.error, 'Unknown error'),
+    }));
+
+  const candidateCards = candidates
+    .map((candidate, index) => {
+      const id = cleanString(candidate.id, `direction-${index + 1}`);
+      const ranking = rankingByDirection.get(id) || {};
+      const rubric = rubricByDirection.get(id) || {};
+      const criteria = asArray(rubric.criteria)
+        .filter((criterion) => criterion && typeof criterion === 'object');
+
+      return {
+        id,
+        label: cleanString(candidate.label, `Direction ${index + 1}`),
+        responseLabel: cleanString(candidate.response_label),
+        sourceModel: cleanString(candidate.source_model, 'Unknown model'),
+        summary: cleanString(candidate.summary),
+        rank: typeof ranking.rank === 'number' ? ranking.rank : null,
+        averageRank: typeof ranking.average_rank === 'number' ? ranking.average_rank : null,
+        rankingsCount: typeof ranking.rankings_count === 'number' ? ranking.rankings_count : null,
+        totalWeight: typeof ranking.total_weight === 'number' ? ranking.total_weight : null,
+        weighted: Boolean(ranking.weighted),
+        overallScore: typeof rubric.overall_score === 'number' ? rubric.overall_score : null,
+        criteria,
+        isSelected: id === selectedDirectionId,
+        originalIndex: index,
+      };
+    })
+    .sort((left, right) => (
+      (left.rank ?? Number.POSITIVE_INFINITY) - (right.rank ?? Number.POSITIVE_INFINITY) ||
+      left.originalIndex - right.originalIndex
+    ));
+
+  const comparisonStatus = cleanString(comparison.status, 'pending');
+  const status = candidateCards.length === 0
+    ? 'empty'
+    : candidateCards.length === 1
+      ? 'single'
+      : comparisonStatus === 'complete'
+        ? 'complete'
+        : 'pending';
+
+  return {
+    status,
+    comparisonStatus,
+    candidateCards,
+    failedVariants,
+    selectedDirectionId,
+    selectedCard: candidateCards.find((card) => card.isSelected) || candidateCards[0] || null,
+    hasPartialFailures: failedVariants.length > 0,
+    hasComparison: candidateCards.length > 1,
+  };
+};

--- a/frontend/src/lib/designStudioWorkspace.test.js
+++ b/frontend/src/lib/designStudioWorkspace.test.js
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  buildDesignStudioWorkspaceView,
+  formatDesignStudioScore,
+} from './designStudioWorkspace.js';
+
+describe('designStudioWorkspace', () => {
+  it('returns an empty workspace for missing candidate metadata', () => {
+    const view = buildDesignStudioWorkspaceView();
+
+    assert.strictEqual(view.status, 'empty');
+    assert.deepStrictEqual(view.candidateCards, []);
+    assert.strictEqual(view.selectedCard, null);
+  });
+
+  it('handles one pending candidate without comparison data', () => {
+    const view = buildDesignStudioWorkspaceView({
+      candidate_directions: [
+        {
+          id: 'direction-a',
+          label: 'Direction A',
+          response_label: 'Response A',
+          source_model: 'model-a',
+          summary: 'A concise product surface.',
+        },
+      ],
+      comparison: { status: 'pending' },
+    });
+
+    assert.strictEqual(view.status, 'single');
+    assert.strictEqual(view.selectedDirectionId, 'direction-a');
+    assert.strictEqual(view.selectedCard.label, 'Direction A');
+    assert.strictEqual(view.candidateCards[0].isSelected, true);
+  });
+
+  it('sorts compared candidates by aggregate rank and attaches scorecards', () => {
+    const view = buildDesignStudioWorkspaceView({
+      candidate_directions: [
+        { id: 'direction-a', label: 'Direction A', source_model: 'model-a' },
+        { id: 'direction-b', label: 'Direction B', source_model: 'model-b' },
+      ],
+      selected_direction_id: 'direction-b',
+      comparison: {
+        status: 'complete',
+        ranked_directions: [
+          {
+            direction_id: 'direction-b',
+            rank: 1,
+            average_rank: 1.2,
+            rankings_count: 3,
+            total_weight: 2.5,
+            weighted: true,
+          },
+          {
+            direction_id: 'direction-a',
+            rank: 2,
+            average_rank: 2,
+            rankings_count: 3,
+          },
+        ],
+        rubric_summaries: [
+          {
+            direction_id: 'direction-b',
+            overall_score: 4.4,
+            criteria: [{ key: 'clarity', label: 'Clarity', average_score: 4.6 }],
+          },
+        ],
+      },
+    });
+
+    assert.strictEqual(view.status, 'complete');
+    assert.strictEqual(view.candidateCards[0].id, 'direction-b');
+    assert.strictEqual(view.candidateCards[0].isSelected, true);
+    assert.strictEqual(view.candidateCards[0].averageRank, 1.2);
+    assert.strictEqual(view.candidateCards[0].overallScore, 4.4);
+    assert.strictEqual(view.candidateCards[0].criteria[0].label, 'Clarity');
+  });
+
+  it('keeps malformed comparison fields and partial failures from breaking the view', () => {
+    const view = buildDesignStudioWorkspaceView(
+      {
+        candidate_directions: [
+          { id: 'direction-a', label: 'Direction A', source_model: 'model-a' },
+          { id: 'direction-b', label: 'Direction B', source_model: 'model-b' },
+        ],
+        comparison: {
+          status: 'complete',
+          ranked_directions: 'bad-data',
+          rubric_summaries: [{ direction_id: 'direction-a', criteria: 'bad-data' }],
+        },
+      },
+      [{ model: 'model-c', error: 'timeout' }]
+    );
+
+    assert.strictEqual(view.status, 'complete');
+    assert.strictEqual(view.hasPartialFailures, true);
+    assert.deepStrictEqual(view.failedVariants, [{ model: 'model-c', error: 'timeout' }]);
+    assert.deepStrictEqual(view.candidateCards[0].criteria, []);
+  });
+
+  it('formats numeric scores for compact UI labels', () => {
+    assert.strictEqual(formatDesignStudioScore(4), '4');
+    assert.strictEqual(formatDesignStudioScore(4.25), '4.3');
+    assert.strictEqual(formatDesignStudioScore(null), 'n/a');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Design Studio workspace panel that renders candidate variants, comparison status, leading direction, scores, and partial failures before the raw synthesis.
- Add a pure workspace metadata normalizer so missing or malformed candidate, ranking, rubric, and failure data stays safe to render.
- Show the workspace during in-progress Design Studio runs as soon as structured metadata is available, while keeping existing council tabs and handoff rendering intact.

## Validation
- node --test frontend/src/lib/designStudioWorkspace.test.js frontend/src/lib/designStudioConfig.test.js
- cd frontend && npm run test
- cd frontend && npm run lint
- cd frontend && npm run build
- uv run pytest tests/test_design_studio.py tests/test_api.py -q
- uv run pytest -q
- Browser QA at http://127.0.0.1:5173/?c=ar102-qa-f95ca764 verified comparison complete, leading Direction B, partial failure, score chips, and no console errors after auth setup.
- Mobile QA at 390x844 verified the workspace renders and document scrollWidth equals viewport width.

## Review
- Pre-landing review found no actionable issues.
- Security pass found no unsafe HTML rendering, credential handling, shell execution, or trust-boundary write changes.
