### PR TITLE
AR-103: Reuse visual review surface in Design Studio

### DIFF
--- a/backend/council.py
+++ b/backend/council.py
@@ -921,7 +921,8 @@ async def run_full_council(
     primary_artifacts: Optional[List[Dict[str, Any]]] = None,
     retrieval_context: Optional[str] = None,
     retrieval_citations: Optional[List[Dict[str, Any]]] = None,
-    conversation_messages: Optional[List[Dict[str, Any]]] = None
+    conversation_messages: Optional[List[Dict[str, Any]]] = None,
+    visual_findings_enabled: Optional[bool] = None,
 ):
     """
     Orchestrates the selected council process.
@@ -1044,11 +1045,17 @@ async def run_full_council(
         execution_context=execution_context,
         aggregate_rankings=aggregate_rankings,
         aggregate_rubrics=aggregate_rubrics,
+        visual_findings_enabled=visual_findings_enabled,
     ):
         stage3_text += chunk
 
     visual_findings: List[Dict[str, Any]] = []
-    if session_type == "visual_review":
+    should_extract_visual_findings = (
+        session_type == "visual_review"
+        if visual_findings_enabled is None
+        else visual_findings_enabled
+    )
+    if should_extract_visual_findings:
         stage3_text, visual_findings = extract_visual_findings_from_response(
             stage3_text,
             primary_artifacts=primary_artifacts,
@@ -1212,6 +1219,7 @@ async def stage3_synthesize_final(
     execution_context: Optional[str] = None,
     aggregate_rankings: Optional[List[Dict[str, Any]]] = None,
     aggregate_rubrics: Optional[List[Dict[str, Any]]] = None,
+    visual_findings_enabled: Optional[bool] = None,
 ):
     """
     Stage 3: Chairman synthesizes final response (streaming).
@@ -1282,8 +1290,13 @@ async def stage3_synthesize_final(
                 )
         weighted_consensus_block = "WEIGHTED CONSENSUS SUMMARY:\n" + "\n".join(summary_lines) + "\n"
     rubric_summary_block = _build_rubric_summary_block(aggregate_rubrics)
+    visual_findings_requested = (
+        session_type == "visual_review"
+        if visual_findings_enabled is None
+        else visual_findings_enabled
+    )
     visual_findings_block = ""
-    if session_type == "visual_review":
+    if visual_findings_requested:
         visual_findings_block = """VISUAL FINDINGS APPENDIX:
 - After the main answer, append a fenced JSON block introduced by the exact heading "VISUAL FINDINGS JSON:".
 - Return an array of up to 6 findings.

--- a/backend/main.py
+++ b/backend/main.py
@@ -480,6 +480,52 @@ def _should_include_image_artifacts(
     return any(openrouter.supports_vision_model(model_id) for model_id in effective_models)
 
 
+DESIGN_STUDIO_VISUAL_CRITIQUE_GOALS = {"review", "iterate", "compare", "handoff"}
+
+
+def _should_enable_visual_artifact_review(conversation: Dict[str, Any]) -> bool:
+    session_type = normalize_session_type(conversation.get("session_type"))
+    if not _get_ready_image_artifacts(conversation.get("primary_artifacts")):
+        return False
+    if session_type == "visual_review":
+        return True
+    if session_type != "design_studio":
+        return False
+
+    session_config = normalize_session_config(
+        conversation.get("session_config"),
+        session_type=session_type,
+    )
+    return session_config.get("studio_goal") in DESIGN_STUDIO_VISUAL_CRITIQUE_GOALS
+
+
+def _build_visual_review_surface_metadata(
+    conversation: Dict[str, Any],
+    visual_findings: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    enabled = _should_enable_visual_artifact_review(conversation)
+    session_type = normalize_session_type(conversation.get("session_type"))
+    mode = "design_studio_critique" if session_type == "design_studio" else "visual_review"
+    findings_count = len(visual_findings or [])
+    artifact_count = len(_get_ready_image_artifacts(conversation.get("primary_artifacts")))
+
+    return {
+        "enabled": enabled,
+        "panel_enabled": enabled and (
+            session_type == "visual_review" or findings_count > 0
+        ),
+        "mode": mode,
+        "tab_label": "Critique" if mode == "design_studio_critique" else "Visual",
+        "title": "Artifact Critique Surface" if mode == "design_studio_critique" else None,
+        "description": (
+            "Inspect artifact-tied critique findings without leaving the Design Studio flow."
+            if mode == "design_studio_critique" else None
+        ),
+        "artifact_count": artifact_count,
+        "findings_count": findings_count,
+    }
+
+
 def _visual_review_requires_vision_models(conversation: Dict[str, Any], effective_models: List[str]) -> None:
     if normalize_session_type(conversation.get("session_type")) == "visual_review" and not effective_models:
         raise HTTPException(
@@ -1077,7 +1123,8 @@ async def send_message(
         primary_artifacts=conversation.get("primary_artifacts"),
         retrieval_context=effective_context,
         retrieval_citations=citations,
-        conversation_messages=conversation.get("messages")
+        conversation_messages=conversation.get("messages"),
+        visual_findings_enabled=_should_enable_visual_artifact_review(conversation),
     )
     metadata["requested_council_models"] = requested_council_models
     metadata["effective_council_models"] = effective_council_models
@@ -1099,6 +1146,10 @@ async def send_message(
     )
     metadata["primary_artifacts"] = conversation.get("primary_artifacts", [])
     metadata["primary_artifact_count"] = len(conversation.get("primary_artifacts") or [])
+    metadata["visual_review"] = _build_visual_review_surface_metadata(
+        conversation,
+        metadata.get("visual_findings"),
+    )
     design_studio_metadata = build_design_studio_metadata(
         session_type=conversation.get("session_type"),
         stage1_results=stage1_results,
@@ -1192,7 +1243,8 @@ async def _rerun_stage2_and_stage3(
     execution_mode: Optional[str],
     primary_artifacts: Optional[List[Dict[str, Any]]],
     retrieval_context: str,
-    conversation_messages: Optional[List[Dict[str, Any]]] = None
+    conversation_messages: Optional[List[Dict[str, Any]]] = None,
+    visual_findings_enabled: Optional[bool] = None,
 ) -> Dict[str, Any]:
     stage2_results: List[Dict[str, Any]] = []
     aggregate_rankings: List[Dict[str, Any]] = []
@@ -1263,6 +1315,7 @@ async def _rerun_stage2_and_stage3(
         execution_context=execution_context,
         aggregate_rankings=aggregate_rankings,
         aggregate_rubrics=aggregate_rubrics,
+        visual_findings_enabled=visual_findings_enabled,
     ):
         full_stage3_response += token
 
@@ -1270,7 +1323,12 @@ async def _rerun_stage2_and_stage3(
         raise RuntimeError("The chairman model returned an empty response.")
 
     visual_findings: List[Dict[str, Any]] = []
-    if session_type == "visual_review":
+    should_extract_visual_findings = (
+        session_type == "visual_review"
+        if visual_findings_enabled is None
+        else visual_findings_enabled
+    )
+    if should_extract_visual_findings:
         full_stage3_response, visual_findings = extract_visual_findings_from_response(
             full_stage3_response,
             primary_artifacts=primary_artifacts,
@@ -1533,7 +1591,8 @@ async def retry_failed_stage1_models(
                     execution_mode=conversation.get("execution_mode"),
                     primary_artifacts=conversation.get("primary_artifacts"),
                     retrieval_context=effective_context,
-                    conversation_messages=messages[:message_index]
+                    conversation_messages=messages[:message_index],
+                    visual_findings_enabled=_should_enable_visual_artifact_review(conversation),
                 )
                 target_message["stage2"] = refreshed_data["stage2"]
                 target_message["stage3"] = refreshed_data["stage3"]
@@ -1542,6 +1601,10 @@ async def retry_failed_stage1_models(
                 metadata["aggregate_rubrics"] = refreshed_data["aggregate_rubrics"]
                 metadata["execution"] = refreshed_data["execution"]
                 metadata["visual_findings"] = refreshed_data["visual_findings"]
+                metadata["visual_review"] = _build_visual_review_surface_metadata(
+                    conversation,
+                    refreshed_data["visual_findings"],
+                )
                 if refreshed_data.get("model_weight_profile"):
                     metadata["model_weight_profile"] = refreshed_data["model_weight_profile"]
                 if refreshed_data.get("ballot_weighting"):
@@ -1681,6 +1744,15 @@ async def send_message_stream(
                 "responded_council_models": responded_council_models,
                 "stage1_errors": stage1_errors,
                 "stage1_duration_seconds": stage1_duration,
+                "session_type": conversation.get("session_type", DEFAULT_SESSION_TYPE),
+                "session_config": normalize_session_config(
+                    conversation.get("session_config"),
+                    session_type=conversation.get("session_type"),
+                ),
+                "specialist_template_id": conversation.get("specialist_template_id"),
+                "primary_artifacts": conversation.get("primary_artifacts", []),
+                "primary_artifact_count": len(conversation.get("primary_artifacts") or []),
+                "visual_review": _build_visual_review_surface_metadata(conversation, []),
             }
             if design_studio_metadata:
                 stage1_meta["design_studio"] = design_studio_metadata
@@ -1710,6 +1782,15 @@ async def send_message_stream(
                 "model_selection": model_selection_metadata,
                 "responded_council_models": responded_council_models,
                 "stage1_errors": stage1_errors,
+                "session_type": conversation.get("session_type", DEFAULT_SESSION_TYPE),
+                "session_config": normalize_session_config(
+                    conversation.get("session_config"),
+                    session_type=conversation.get("session_type"),
+                ),
+                "specialist_template_id": conversation.get("specialist_template_id"),
+                "primary_artifacts": conversation.get("primary_artifacts", []),
+                "primary_artifact_count": len(conversation.get("primary_artifacts") or []),
+                "visual_review": _build_visual_review_surface_metadata(conversation, []),
             }
             hetero_meta = {}
             design_stage_meta = design_studio_metadata
@@ -1806,6 +1887,7 @@ async def send_message_stream(
             # Stage 3: Synthesize final answer (Streaming)
             yield f"data: {json.dumps({'type': 'stage3_start'})}\n\n"
             stage3_start = time.monotonic()
+            visual_findings_enabled = _should_enable_visual_artifact_review(conversation)
             full_stage3_response = ""
             async for token in stage3_synthesize_final(
                 request.content,
@@ -1819,6 +1901,7 @@ async def send_message_stream(
                 execution_context=execution_context,
                 aggregate_rankings=aggregate_rankings,
                 aggregate_rubrics=aggregate_rubrics,
+                visual_findings_enabled=visual_findings_enabled,
             ):
                 full_stage3_response += token
                 yield f"data: {json.dumps({'type': 'stage3_token', 'data': token})}\n\n"
@@ -1827,7 +1910,7 @@ async def send_message_stream(
                 raise RuntimeError("The chairman model returned an empty response.")
 
             visual_findings: List[Dict[str, Any]] = []
-            if conversation.get("session_type") == "visual_review":
+            if visual_findings_enabled:
                 full_stage3_response, visual_findings = extract_visual_findings_from_response(
                     full_stage3_response,
                     primary_artifacts=conversation.get("primary_artifacts"),
@@ -1846,6 +1929,19 @@ async def send_message_stream(
                 aggregate_rubrics=aggregate_rubrics,
             )
             stage3_metadata = {"design_studio": design_stage_meta} if design_stage_meta else {}
+            stage3_metadata["session_type"] = conversation.get("session_type", DEFAULT_SESSION_TYPE)
+            stage3_metadata["session_config"] = normalize_session_config(
+                conversation.get("session_config"),
+                session_type=conversation.get("session_type"),
+            )
+            stage3_metadata["specialist_template_id"] = conversation.get("specialist_template_id")
+            stage3_metadata["primary_artifacts"] = conversation.get("primary_artifacts", [])
+            stage3_metadata["primary_artifact_count"] = len(conversation.get("primary_artifacts") or [])
+            stage3_metadata["visual_review"] = _build_visual_review_surface_metadata(
+                conversation,
+                visual_findings,
+            )
+            stage3_metadata["visual_findings"] = visual_findings
             yield f"data: {json.dumps({'type': 'stage3_complete', 'data': stage3_result, 'metadata': stage3_metadata})}\n\n"
             stage3_duration = round(time.monotonic() - stage3_start, 3)
             logger.info(f"[stream] conversation={conversation_id} stage3_complete duration={stage3_duration}s")
@@ -1871,6 +1967,7 @@ async def send_message_stream(
                 "aggregate_rubrics": aggregate_rubrics,
                 "execution": execution_report,
                 "visual_findings": visual_findings,
+                "visual_review": _build_visual_review_surface_metadata(conversation, visual_findings),
                 "stage1_errors": stage1_errors,
                 "session_type": conversation.get("session_type", DEFAULT_SESSION_TYPE),
                 "specialist_template_id": conversation.get("specialist_template_id"),

--- a/frontend/src/components/CouncilMessageBlock.jsx
+++ b/frontend/src/components/CouncilMessageBlock.jsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { AlertTriangle, Trophy, Crown, BrainCircuit, CheckCircle2, FileImage, GitCompareArrows, PauseCircle, RefreshCw, RotateCcw, Wrench, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { buildDesignStudioWorkspaceView, formatDesignStudioScore } from "@/lib/designStudioWorkspace";
+import { buildVisualReviewSurface } from "@/lib/visualReviewSurface";
 import VisualReviewPanel from './VisualReviewPanel';
 
 // ⚡ Bolt: Memoize markdown rendering to prevent re-parsing on every parent re-render
@@ -779,13 +780,8 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
   const modelWeightProfile = Array.isArray(metadata?.model_weight_profile)
     ? metadata.model_weight_profile
     : [];
-  const visualArtifacts = Array.isArray(metadata?.primary_artifacts)
-    ? metadata.primary_artifacts.filter((artifact) => artifact?.kind === 'image' && artifact?.preview_url)
-    : EMPTY_LIST;
-  const visualFindings = Array.isArray(metadata?.visual_findings)
-    ? metadata.visual_findings
-    : EMPTY_LIST;
-  const hasVisualReviewTab = metadata?.session_type === 'visual_review' && visualArtifacts.length > 0;
+  const visualReviewSurface = useMemo(() => buildVisualReviewSurface(metadata), [metadata]);
+  const hasVisualReviewTab = visualReviewSurface.shouldShow;
   const hasExecutionTab = Boolean(executionReport);
   const designStudioMetadata = metadata?.session_type === 'design_studio'
     ? metadata?.design_studio
@@ -932,7 +928,7 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
             {hasVisualReviewTab && (
               <TabsTrigger value="visual" className="gap-2">
                 <FileImage className="h-3.5 w-3.5 text-sky-500" />
-                Visual
+                {visualReviewSurface.tabLabel}
               </TabsTrigger>
             )}
             {hasExecutionTab && (
@@ -1052,7 +1048,12 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
           </TabsContent>
 
           <TabsContent value="visual" className="m-0 focus-visible:ring-0">
-            <VisualReviewPanel artifacts={visualArtifacts} findings={visualFindings} />
+            <VisualReviewPanel
+              artifacts={visualReviewSurface.imageArtifacts}
+              findings={visualReviewSurface.findings}
+              title={visualReviewSurface.title}
+              description={visualReviewSurface.description}
+            />
           </TabsContent>
 
           <TabsContent value="execution" className="m-0 focus-visible:ring-0">

--- a/frontend/src/components/VisualReviewPanel.jsx
+++ b/frontend/src/components/VisualReviewPanel.jsx
@@ -13,7 +13,12 @@ function severityClass(severity) {
   return SEVERITY_STYLES[severity] || SEVERITY_STYLES.medium;
 }
 
-export default function VisualReviewPanel({ artifacts = [], findings = [] }) {
+export default function VisualReviewPanel({
+  artifacts = [],
+  findings = [],
+  title,
+  description,
+}) {
   const imageArtifacts = useMemo(
     () => (Array.isArray(artifacts) ? artifacts : []).filter((artifact) =>
       artifact?.kind === 'image' && artifact?.preview_url
@@ -48,12 +53,12 @@ export default function VisualReviewPanel({ artifacts = [], findings = [] }) {
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
           <h3 className="font-semibold">
-            {hasComparison ? 'Side-by-Side Comparison' : 'Visual Review Surface'}
+            {title || (hasComparison ? 'Side-by-Side Comparison' : 'Visual Review Surface')}
           </h3>
           <p className="text-sm text-muted-foreground">
-            {hasComparison
+            {description || (hasComparison
               ? 'Review both artifacts together and inspect region-tied findings directly on the images.'
-              : 'Inspect the uploaded artifact and jump through structured visual findings.'}
+              : 'Inspect the uploaded artifact and jump through structured visual findings.')}
           </p>
         </div>
         <Badge variant="outline">{structuredFindings.length} findings</Badge>

--- a/frontend/src/lib/visualReviewSurface.js
+++ b/frontend/src/lib/visualReviewSurface.js
@@ -1,0 +1,47 @@
+const EMPTY_LIST = [];
+
+const asArray = (value) => (Array.isArray(value) ? value : EMPTY_LIST);
+
+const isStructuredFinding = (finding) => (
+  Boolean(
+    finding?.artifact_id &&
+    typeof finding?.title === 'string' &&
+    typeof finding?.comment === 'string'
+  )
+);
+
+export const buildVisualReviewSurface = (metadata = {}) => {
+  const imageArtifacts = asArray(metadata?.primary_artifacts)
+    .filter((artifact) => artifact?.kind === 'image' && artifact?.preview_url);
+  const findings = asArray(metadata?.visual_findings).filter(isStructuredFinding);
+  const surfaceMetadata = metadata?.visual_review && typeof metadata.visual_review === 'object'
+    ? metadata.visual_review
+    : {};
+  const sessionType = metadata?.session_type;
+  const isVisualReviewSession = sessionType === 'visual_review';
+  const isDesignStudioSession = sessionType === 'design_studio';
+  const metadataEnabled = surfaceMetadata.panel_enabled === true || surfaceMetadata.enabled === true;
+  const shouldShow = imageArtifacts.length > 0 && (
+    isVisualReviewSession ||
+    (findings.length > 0 && (metadataEnabled || isDesignStudioSession))
+  );
+  const mode = surfaceMetadata.mode || (
+    isDesignStudioSession ? 'design_studio_critique' : 'visual_review'
+  );
+
+  return {
+    shouldShow,
+    imageArtifacts,
+    findings,
+    mode,
+    tabLabel: surfaceMetadata.tab_label || (mode === 'design_studio_critique' ? 'Critique' : 'Visual'),
+    title: surfaceMetadata.title || (
+      mode === 'design_studio_critique' ? 'Artifact Critique Surface' : undefined
+    ),
+    description: surfaceMetadata.description || (
+      mode === 'design_studio_critique'
+        ? 'Inspect artifact-tied critique findings without leaving the Design Studio flow.'
+        : undefined
+    ),
+  };
+};

--- a/frontend/src/lib/visualReviewSurface.test.js
+++ b/frontend/src/lib/visualReviewSurface.test.js
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { buildVisualReviewSurface } from './visualReviewSurface.js';
+
+const imageArtifact = {
+  id: 'img-1',
+  kind: 'image',
+  preview_url: '/artifact-files/mock.png',
+};
+
+const finding = {
+  id: 'visual-finding-1',
+  artifact_id: 'img-1',
+  title: 'Weak contrast',
+  comment: 'The primary action is hard to see.',
+};
+
+describe('visualReviewSurface', () => {
+  it('preserves visual review sessions even before findings exist', () => {
+    const surface = buildVisualReviewSurface({
+      session_type: 'visual_review',
+      primary_artifacts: [imageArtifact],
+      visual_findings: [],
+    });
+
+    assert.strictEqual(surface.shouldShow, true);
+    assert.strictEqual(surface.tabLabel, 'Visual');
+  });
+
+  it('shows Design Studio critique when image findings are available', () => {
+    const surface = buildVisualReviewSurface({
+      session_type: 'design_studio',
+      primary_artifacts: [imageArtifact],
+      visual_findings: [finding],
+      visual_review: {
+        panel_enabled: true,
+        mode: 'design_studio_critique',
+      },
+    });
+
+    assert.strictEqual(surface.shouldShow, true);
+    assert.strictEqual(surface.tabLabel, 'Critique');
+    assert.strictEqual(surface.title, 'Artifact Critique Surface');
+    assert.strictEqual(surface.findings.length, 1);
+  });
+
+  it('does not show Design Studio image panels without artifact-tied findings', () => {
+    const surface = buildVisualReviewSurface({
+      session_type: 'design_studio',
+      primary_artifacts: [imageArtifact],
+      visual_findings: [],
+      visual_review: { panel_enabled: true },
+    });
+
+    assert.strictEqual(surface.shouldShow, false);
+  });
+
+  it('ignores incomplete findings and non-image artifacts', () => {
+    const surface = buildVisualReviewSurface({
+      session_type: 'design_studio',
+      primary_artifacts: [{ id: 'doc-1', kind: 'document', preview_url: '/doc' }],
+      visual_findings: [{ artifact_id: 'img-1', title: 'Missing comment' }],
+      visual_review: { panel_enabled: true },
+    });
+
+    assert.strictEqual(surface.shouldShow, false);
+    assert.deepStrictEqual(surface.imageArtifacts, []);
+    assert.deepStrictEqual(surface.findings, []);
+  });
+});

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -721,6 +721,107 @@ async def test_send_message_stream_design_studio_emits_structured_stage_metadata
 
 
 @pytest.mark.asyncio
+async def test_send_message_stream_design_studio_with_image_findings_enables_critique_surface(async_client):
+    conversation = {
+        "id": "conv-design-image-stream",
+        "framework": "standard",
+        "session_type": "design_studio",
+        "specialist_template_id": "design_web_app_studio",
+        "session_config": {
+            "design_target": "web_app",
+            "studio_goal": "review",
+            "approved_direction_id": None,
+        },
+        "council_models": ["vision-a", "vision-b"],
+        "chairman_model": "chair-model",
+        "primary_artifacts": [
+            {
+                "id": "img-1",
+                "kind": "image",
+                "label": "mockup.png",
+                "source": "upload",
+                "status": "ready",
+                "filename": "mockup.png",
+                "mime_type": "image/png",
+                "size_bytes": 128,
+                "storage_path": "conv-design-image-stream/img-1.png",
+                "preview_url": "/artifact-files/conv-design-image-stream/img-1.png",
+            }
+        ],
+        "messages": [],
+    }
+
+    async def mock_stage1_stream(*args, **kwargs):
+        yield {"model": "vision-a", "response": "Direction A critiques the current hero."}
+        yield {"model": "vision-b", "response": "Direction B critiques the current card layout."}
+
+    async def mock_stage3_stream(*args, **kwargs):
+        yield """Ship Direction A.
+
+VISUAL FINDINGS JSON:
+```json
+[
+  {
+    "artifact_label": "mockup.png",
+    "title": "CTA lacks contrast",
+    "comment": "The primary action is too low contrast against the background.",
+    "severity": "high",
+    "x": 60,
+    "y": 20,
+    "w": 18,
+    "h": 10
+  }
+]
+```"""
+
+    app.dependency_overrides[auth.get_current_user_id] = lambda: "test_user"
+    try:
+        with patch("backend.storage.get_conversation", new_callable=AsyncMock) as mock_get_conversation, \
+             patch("backend.storage.add_user_message", new_callable=AsyncMock), \
+             patch("backend.storage.update_conversation_title", new_callable=AsyncMock), \
+             patch("backend.storage.add_assistant_message", new_callable=AsyncMock) as mock_add_assistant_message, \
+             patch("backend.retrieval.build_retrieval_context", new_callable=AsyncMock) as mock_retrieval, \
+             patch("backend.main.generate_conversation_title", new_callable=AsyncMock) as mock_generate_title, \
+             patch("backend.main.stage1_collect_responses", side_effect=mock_stage1_stream), \
+             patch("backend.main.stage2_collect_rankings", new_callable=AsyncMock) as mock_stage2, \
+             patch("backend.main.stage3_synthesize_final", side_effect=mock_stage3_stream) as mock_stage3, \
+             patch("backend.openrouter.supports_vision_model", return_value=True), \
+             patch("backend.image_artifacts.load_image_as_data_url", return_value="data:image/png;base64,abc"):
+            mock_get_conversation.return_value = conversation
+            mock_retrieval.return_value = ("", [])
+            mock_generate_title.return_value = "Design Image Review"
+            mock_stage2.return_value = (
+                [{"model": "judge", "ranking": "FINAL RANKING:\n1. Response A\n2. Response B"}],
+                {"Response A": "vision-a", "Response B": "vision-b"},
+            )
+
+            async with async_client.stream(
+                "POST",
+                "/api/conversations/conv-design-image-stream/message/stream",
+                json={"content": "Critique this mockup"},
+            ) as response:
+                assert response.status_code == 200
+                events = []
+                async for line in response.aiter_lines():
+                    if line.startswith("data: "):
+                        events.append(json.loads(line[6:]))
+
+            stage3_complete = next(event for event in events if event["type"] == "stage3_complete")
+            assert stage3_complete["data"]["response"] == "Ship Direction A."
+            assert stage3_complete["metadata"]["visual_review"]["panel_enabled"] is True
+            assert stage3_complete["metadata"]["visual_review"]["mode"] == "design_studio_critique"
+            assert stage3_complete["metadata"]["visual_review"]["tab_label"] == "Critique"
+            assert stage3_complete["metadata"]["visual_findings"][0]["artifact_id"] == "img-1"
+
+            assert mock_stage3.call_args.kwargs["visual_findings_enabled"] is True
+            saved_metadata = mock_add_assistant_message.await_args.args[5]
+            assert saved_metadata["visual_review"]["panel_enabled"] is True
+            assert saved_metadata["visual_findings"][0]["title"] == "CTA lacks contrast"
+    finally:
+        app.dependency_overrides = {}
+
+
+@pytest.mark.asyncio
 async def test_send_message_code_review_returns_execution_metadata(async_client):
     conversation = {
         "id": "conv-exec",

--- a/tests/test_council.py
+++ b/tests/test_council.py
@@ -177,6 +177,46 @@ async def test_stage3_synthesis_visual_review_requests_visual_findings_json():
     assert "Coordinates must be normalized percentages" in prompt
 
 
+@pytest.mark.asyncio
+async def test_stage3_synthesis_design_studio_can_request_visual_findings_json():
+    async def mock_stream(*args, **kwargs):
+        yield "Final"
+
+    with patch("backend.council.query_model_stream", side_effect=mock_stream) as mock_stream_fn:
+        async for _token in council.stage3_synthesize_final(
+            "Critique this mockup",
+            [{"model": "gpt-4", "response": "Resp"}],
+            [{"model": "claude-3", "ranking": "Feedback"}],
+            "chairman-model",
+            session_type="design_studio",
+            visual_findings_enabled=True,
+        ):
+            pass
+
+    prompt = mock_stream_fn.call_args.args[1][0]["content"]
+    assert "VISUAL FINDINGS JSON" in prompt
+    assert "artifact_label" in prompt
+
+
+@pytest.mark.asyncio
+async def test_stage3_synthesis_design_studio_skips_visual_findings_by_default():
+    async def mock_stream(*args, **kwargs):
+        yield "Final"
+
+    with patch("backend.council.query_model_stream", side_effect=mock_stream) as mock_stream_fn:
+        async for _token in council.stage3_synthesize_final(
+            "Generate options",
+            [{"model": "gpt-4", "response": "Resp"}],
+            [{"model": "claude-3", "ranking": "Feedback"}],
+            "chairman-model",
+            session_type="design_studio",
+        ):
+            pass
+
+    prompt = mock_stream_fn.call_args.args[1][0]["content"]
+    assert "VISUAL FINDINGS JSON" not in prompt
+
+
 def test_parse_confidence_from_text():
     assert council.parse_confidence_from_text("FINAL RANKING:\n1. Response A\nCONFIDENCE: 82") == 82
     assert council.parse_confidence_from_text("confidence: 150") == 100


### PR DESCRIPTION
## Summary
- Reuse the existing VisualReviewPanel for Design Studio image critique flows through metadata-driven surface eligibility.
- Add backend visual surface metadata and opt-in visual findings extraction for Design Studio review, iterate, compare, and handoff goals with ready image artifacts.
- Preserve existing Visual Review behavior while allowing Design Studio to show a Critique tab only when artifact-tied findings exist.
- Include session and artifact metadata in streamed stage events so Design Studio workspace and critique surfaces can render live before a reload.

## Validation
- node --test frontend/src/lib/visualReviewSurface.test.js frontend/src/lib/designStudioWorkspace.test.js
- cd frontend && npm run test
- cd frontend && npm run lint
- cd frontend && npm run build
- uv run pytest tests/test_council.py tests/test_api.py -q
- uv run pytest -q
- Browser QA verified Design Studio image critique shows a Critique tab, artifact surface, hotspot count, and finding with no console errors.
- Browser QA verified Visual Review still shows a Visual tab and does not get renamed to Critique.

## Review
- Pre-landing review found no actionable issues.
- Security pass found no unsafe HTML rendering, credential handling, shell execution, or new unbounded trust-boundary writes.
