### PR TITLE
AR-104: Approve Design Studio directions for refinement

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -152,6 +152,19 @@ class CreateConversationRequest(BaseModel):
         return self
 
 
+class ApproveDesignDirectionRequest(BaseModel):
+    """Request to approve a Design Studio direction for future refinement."""
+    direction_id: str = Field(..., min_length=1, max_length=120)
+
+    @field_validator("direction_id")
+    @classmethod
+    def validate_direction_id(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Direction ID is required")
+        return cleaned
+
+
 class SendMessageRequest(BaseModel):
     """Request to send a message in a conversation."""
     content: str = Field(..., max_length=50000)
@@ -526,6 +539,27 @@ def _build_visual_review_surface_metadata(
     }
 
 
+def _get_design_studio_candidate_ids(conversation: Dict[str, Any]) -> set[str]:
+    candidate_ids: set[str] = set()
+    for message in conversation.get("messages") or []:
+        if not isinstance(message, dict):
+            continue
+        metadata = message.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        design_studio = metadata.get("design_studio")
+        if not isinstance(design_studio, dict):
+            continue
+        candidates = design_studio.get("candidate_directions")
+        if not isinstance(candidates, list):
+            continue
+        for candidate in candidates:
+            candidate_id = candidate.get("id") if isinstance(candidate, dict) else None
+            if isinstance(candidate_id, str) and candidate_id.strip():
+                candidate_ids.add(candidate_id.strip())
+    return candidate_ids
+
+
 def _visual_review_requires_vision_models(conversation: Dict[str, Any], effective_models: List[str]) -> None:
     if normalize_session_type(conversation.get("session_type")) == "visual_review" and not effective_models:
         raise HTTPException(
@@ -730,6 +764,43 @@ async def get_conversation(
     if conversation is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
     return conversation
+
+
+@app.post("/api/conversations/{conversation_id}/design-studio/approved-direction", response_model=Conversation)
+async def approve_design_direction(
+    conversation_id: str,
+    request: ApproveDesignDirectionRequest,
+    user_id: str = Depends(auth.get_current_user_id),
+):
+    """Persist the chosen Design Studio direction and switch future turns into refinement."""
+    conversation = await storage.get_conversation(conversation_id, user_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    if normalize_session_type(conversation.get("session_type")) != "design_studio":
+        raise HTTPException(
+            status_code=400,
+            detail="Approved directions are only available for Design Studio sessions.",
+        )
+    candidate_ids = _get_design_studio_candidate_ids(conversation)
+    if candidate_ids and request.direction_id not in candidate_ids:
+        raise HTTPException(status_code=400, detail="Direction is not available in this Design Studio session.")
+
+    current_config = normalize_session_config(
+        conversation.get("session_config"),
+        session_type="design_studio",
+    )
+    next_config = {
+        **current_config,
+        "studio_goal": "iterate",
+        "approved_direction_id": request.direction_id,
+    }
+
+    return await storage.update_conversation_context(
+        conversation_id,
+        user_id,
+        session_config=next_config,
+    )
 
 
 @app.get("/api/conversations/{conversation_id}/documents", response_model=List[DocumentMetadata])

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -145,6 +145,48 @@ function App() {
     }
   }, [isMobile]);
 
+  const handleApproveDesignDirection = useCallback(async (directionId) => {
+    if (!currentConversationId || !directionId) return null;
+    try {
+      const updated = await api.approveDesignDirection(currentConversationId, directionId);
+      const patched = {
+        ...updated,
+        messages: Array.isArray(updated.messages)
+          ? updated.messages.map((message) => (
+            message?.role === 'assistant'
+              ? {
+                ...message,
+                metadata: {
+                  ...(message.metadata || {}),
+                  session_config: updated.session_config,
+                },
+              }
+              : message
+          ))
+          : updated.messages,
+      };
+      setCurrentConversation(patched);
+      setConversations((prev) =>
+        prev.map((conversation) =>
+          conversation.id === updated.id ? { ...conversation, ...patched } : conversation
+        )
+      );
+      toast({
+        title: 'Direction approved',
+        description: 'Future Design Studio turns will refine the selected direction.',
+      });
+      return patched;
+    } catch (error) {
+      logger.error('Failed to approve Design Studio direction:', error);
+      toast({
+        title: 'Could not approve direction',
+        description: error.message || 'Please try again.',
+        variant: 'destructive',
+      });
+      throw error;
+    }
+  }, [currentConversationId, toast]);
+
   const handleSidebarClose = useCallback(() => {
     setIsSidebarOpen(false);
   }, []);
@@ -570,6 +612,7 @@ function App() {
             conversation={currentConversation}
             onSendMessage={handleSendMessage}
             onRetryFailedModels={handleRetryFailedModels}
+            onApproveDesignDirection={handleApproveDesignDirection}
             onConversationRefresh={handleRefreshCurrentConversation}
             isLoading={isLoading}
             isMobile={isMobile}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -203,6 +203,32 @@ export const api = {
   },
 
   /**
+   * Approve a Design Studio direction for future refinement.
+   */
+  async approveDesignDirection(conversationId, directionId) {
+    const response = await fetch(
+      `${API_BASE}/api/conversations/${conversationId}/design-studio/approved-direction`,
+      {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({ direction_id: directionId }),
+      }
+    );
+    if (!response.ok) {
+      let detail = 'Failed to approve direction';
+      try {
+        const data = await response.json();
+        detail = data.detail || data.error || detail;
+      } catch {
+        const text = await response.text();
+        if (text) detail = text;
+      }
+      throw new Error(detail);
+    }
+    return response.json();
+  },
+
+  /**
    * Send a message in a conversation.
    */
   async sendMessage(conversationId, content) {

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -16,6 +16,7 @@ export default function ChatInterface({
   conversation,
   onSendMessage,
   onRetryFailedModels,
+  onApproveDesignDirection,
   onConversationRefresh,
   isLoading,
   isMobile = false,
@@ -286,6 +287,8 @@ export default function ChatInterface({
                       msg={msg}
                       messageIndex={index}
                       onRetryFailedModels={onRetryFailedModels}
+                      onApproveDesignDirection={onApproveDesignDirection}
+                      conversationSessionConfig={conversation.session_config}
                     />
                   </div>
                 );

--- a/frontend/src/components/CouncilMessageBlock.jsx
+++ b/frontend/src/components/CouncilMessageBlock.jsx
@@ -468,15 +468,32 @@ const designWorkspaceStatusCopy = {
   complete: 'Comparison complete',
 };
 
-const DesignStudioWorkspacePanel = memo(({ designStudio, stage1Errors }) => {
+const DesignStudioWorkspacePanel = memo(({
+  designStudio,
+  stage1Errors,
+  approvedDirectionId,
+  onApproveDesignDirection,
+}) => {
   const workspace = useMemo(
     () => buildDesignStudioWorkspaceView(designStudio, stage1Errors),
     [designStudio, stage1Errors]
   );
+  const [approvingDirectionId, setApprovingDirectionId] = useState(null);
 
   if (!designStudio) return null;
 
   const selectedLabel = workspace.selectedCard?.label || workspace.selectedDirectionId || 'No leading direction';
+  const canApprove = typeof onApproveDesignDirection === 'function';
+
+  const handleApprove = async (directionId) => {
+    if (!canApprove || !directionId || approvingDirectionId) return;
+    setApprovingDirectionId(directionId);
+    try {
+      await onApproveDesignDirection(directionId);
+    } finally {
+      setApprovingDirectionId(null);
+    }
+  };
 
   return (
     <div className="mb-5 overflow-hidden rounded-xl border border-violet-500/20 bg-background">
@@ -501,6 +518,11 @@ const DesignStudioWorkspacePanel = memo(({ designStudio, stage1Errors }) => {
             {workspace.selectedCard && (
               <Badge variant="outline" className="text-xs">
                 Leading: {selectedLabel}
+              </Badge>
+            )}
+            {approvedDirectionId && (
+              <Badge variant="outline" className="border-emerald-500/30 bg-emerald-500/10 text-xs text-emerald-700 dark:text-emerald-300">
+                Approved: {approvedDirectionId}
               </Badge>
             )}
           </div>
@@ -540,70 +562,100 @@ const DesignStudioWorkspacePanel = memo(({ designStudio, stage1Errors }) => {
 
             <div className="grid gap-3 lg:grid-cols-2">
               {workspace.candidateCards.map((card) => (
-                <div
-                  key={card.id}
-                  className={cn(
-                    'rounded-lg border bg-card/60 p-4',
-                    card.isSelected && 'border-emerald-500/40 bg-emerald-500/10'
-                  )}
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <h3 className="text-sm font-semibold">{card.label}</h3>
-                        {card.isSelected && (
-                          <Badge className="gap-1 border border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300">
-                            <Trophy className="h-3 w-3" />
-                            Leading
-                          </Badge>
+                <div key={card.id}>
+                  {(() => {
+                    const isApproved = card.id === approvedDirectionId;
+                    const isApproving = approvingDirectionId === card.id;
+
+                    return (
+                      <div
+                        className={cn(
+                          'rounded-lg border bg-card/60 p-4',
+                          card.isSelected && 'border-emerald-500/40 bg-emerald-500/10',
+                          isApproved && 'ring-1 ring-emerald-500/40'
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <h3 className="text-sm font-semibold">{card.label}</h3>
+                              {card.isSelected && (
+                                <Badge className="gap-1 border border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300">
+                                  <Trophy className="h-3 w-3" />
+                                  Leading
+                                </Badge>
+                              )}
+                              {isApproved && (
+                                <Badge className="gap-1 border border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300">
+                                  <CheckCircle2 className="h-3 w-3" />
+                                  Approved
+                                </Badge>
+                              )}
+                            </div>
+                            <div className="mt-1 text-xs text-muted-foreground">
+                              {card.sourceModel}
+                            </div>
+                          </div>
+                          {card.rank && (
+                            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-bold">
+                              {card.rank}
+                            </div>
+                          )}
+                        </div>
+
+                        {card.summary ? (
+                          <p className="mt-3 text-sm text-foreground/85">{card.summary}</p>
+                        ) : (
+                          <p className="mt-3 text-sm text-muted-foreground">No summary captured for this variant.</p>
+                        )}
+
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          <Badge variant="outline">Avg rank {formatDesignStudioScore(card.averageRank)}</Badge>
+                          <Badge variant="outline">Score {formatDesignStudioScore(card.overallScore)}/5</Badge>
+                          {card.rankingsCount !== null && (
+                            <Badge variant="outline">{card.rankingsCount} evaluations</Badge>
+                          )}
+                          {card.totalWeight !== null && (
+                            <Badge variant="outline">Weight {formatDesignStudioScore(card.totalWeight)}</Badge>
+                          )}
+                        </div>
+
+                        {card.criteria.length > 0 && (
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {card.criteria.slice(0, 4).map((criterion, index) => {
+                              const criterionLabel = criterion.label || criterion.key || 'Criterion';
+                              return (
+                                <div
+                                  key={`${card.id}-${criterionLabel}-${index}`}
+                                  className={cn(
+                                    'rounded-full border px-2.5 py-1 text-xs font-medium',
+                                    rubricToneClass(criterion.average_score)
+                                  )}
+                                >
+                                  {criterionLabel} {formatDesignStudioScore(criterion.average_score)}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+
+                        {canApprove && (
+                          <div className="mt-4">
+                            <Button
+                              type="button"
+                              variant={isApproved ? 'secondary' : 'outline'}
+                              size="sm"
+                              onClick={() => handleApprove(card.id)}
+                              disabled={isApproved || Boolean(approvingDirectionId)}
+                            >
+                              <CheckCircle2 className={cn('mr-1 h-3.5 w-3.5', isApproving && 'animate-pulse')} />
+                              {isApproved ? 'Approved for Refinement' : isApproving ? 'Approving...' : 'Approve Direction'}
+                            </Button>
+                          </div>
                         )}
                       </div>
-                      <div className="mt-1 text-xs text-muted-foreground">
-                        {card.sourceModel}
-                      </div>
-                    </div>
-                    {card.rank && (
-                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-bold">
-                        {card.rank}
-                      </div>
-                    )}
-                  </div>
-
-                  {card.summary ? (
-                    <p className="mt-3 text-sm text-foreground/85">{card.summary}</p>
-                  ) : (
-                    <p className="mt-3 text-sm text-muted-foreground">No summary captured for this variant.</p>
-                  )}
-
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    <Badge variant="outline">Avg rank {formatDesignStudioScore(card.averageRank)}</Badge>
-                    <Badge variant="outline">Score {formatDesignStudioScore(card.overallScore)}/5</Badge>
-                    {card.rankingsCount !== null && (
-                      <Badge variant="outline">{card.rankingsCount} evaluations</Badge>
-                    )}
-                    {card.totalWeight !== null && (
-                      <Badge variant="outline">Weight {formatDesignStudioScore(card.totalWeight)}</Badge>
-                    )}
-                  </div>
-
-                  {card.criteria.length > 0 && (
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      {card.criteria.slice(0, 4).map((criterion, index) => {
-                        const criterionLabel = criterion.label || criterion.key || 'Criterion';
-                        return (
-                          <div
-                            key={`${card.id}-${criterionLabel}-${index}`}
-                            className={cn(
-                              'rounded-full border px-2.5 py-1 text-xs font-medium',
-                              rubricToneClass(criterion.average_score)
-                            )}
-                          >
-                            {criterionLabel} {formatDesignStudioScore(criterion.average_score)}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
+                    );
+                  })()}
                 </div>
               ))}
             </div>
@@ -758,7 +810,13 @@ const buildComparisonDiff = (stage1Results) => {
   return { consensusSentences, overlaps, uniqueTerms };
 };
 
-const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => {
+const CouncilMessageBlock = ({
+  message,
+  messageIndex,
+  onRetryFailedModels,
+  onApproveDesignDirection,
+  conversationSessionConfig,
+}) => {
   const { stage1, stage2, stage3, loading, errors, metadata } = message;
   const [activeTab, setActiveTab] = useState('consensus');
   const [isRetryingFailedModels, setIsRetryingFailedModels] = useState(false);
@@ -786,6 +844,11 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
   const designStudioMetadata = metadata?.session_type === 'design_studio'
     ? metadata?.design_studio
     : null;
+  const approvedDirectionId = (
+    metadata?.session_config?.approved_direction_id ||
+    conversationSessionConfig?.approved_direction_id ||
+    null
+  );
   const designStudioHandoff = (
     designStudioMetadata?.handoff?.status === 'ready'
   )
@@ -1014,14 +1077,24 @@ const CouncilMessageBlock = ({ message, messageIndex, onRetryFailedModels }) => 
                       </Button>
                     </div>
                   )}
-                  <DesignStudioWorkspacePanel designStudio={designStudioMetadata} stage1Errors={stage1Errors} />
+                  <DesignStudioWorkspacePanel
+                    designStudio={designStudioMetadata}
+                    stage1Errors={stage1Errors}
+                    approvedDirectionId={approvedDirectionId}
+                    onApproveDesignDirection={onApproveDesignDirection}
+                  />
                   <DesignStudioHandoffPanel handoff={designStudioHandoff} />
                   <MarkdownContent content={stage3.response} />
                   {loading?.stage3 && <span className="inline-block w-2 h-4 bg-primary animate-pulse ml-1" />}
                 </>
               ) : (
                 <>
-                  <DesignStudioWorkspacePanel designStudio={designStudioMetadata} stage1Errors={stage1Errors} />
+                  <DesignStudioWorkspacePanel
+                    designStudio={designStudioMetadata}
+                    stage1Errors={stage1Errors}
+                    approvedDirectionId={approvedDirectionId}
+                    onApproveDesignDirection={onApproveDesignDirection}
+                  />
                   <div className="flex flex-col items-center justify-center p-8 text-muted-foreground gap-3">
                     <BrainCircuit className="h-8 w-8 animate-pulse text-primary/50" />
                     <p>The Council is deliberating...</p>

--- a/frontend/src/components/MessageItem.jsx
+++ b/frontend/src/components/MessageItem.jsx
@@ -5,7 +5,13 @@ import CouncilMessageBlock from './CouncilMessageBlock';
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { User } from "lucide-react";
 
-const MessageItem = memo(({ msg, messageIndex, onRetryFailedModels }) => {
+const MessageItem = memo(({
+  msg,
+  messageIndex,
+  onRetryFailedModels,
+  onApproveDesignDirection,
+  conversationSessionConfig,
+}) => {
   if (msg.role === 'user') {
     return (
       <div className="flex justify-end mb-6">
@@ -41,6 +47,8 @@ const MessageItem = memo(({ msg, messageIndex, onRetryFailedModels }) => {
             message={msg}
             messageIndex={messageIndex}
             onRetryFailedModels={onRetryFailedModels}
+            onApproveDesignDirection={onApproveDesignDirection}
+            conversationSessionConfig={conversationSessionConfig}
           />
         </div>
       </div>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -351,6 +351,147 @@ async def test_create_conversation_persists_design_studio_session_config(async_c
 
 
 @pytest.mark.asyncio
+async def test_approve_design_direction_persists_refinement_config(async_client):
+    conversation = {
+        "id": "conv-approve",
+        "created_at": "2026-01-01T00:00:00",
+        "title": "Approve Direction",
+        "framework": "standard",
+        "session_type": "design_studio",
+        "session_config": {
+            "design_target": "web_app",
+            "studio_goal": "compare",
+            "approved_direction_id": None,
+        },
+        "council_models": ["model-a"],
+        "chairman_model": "chair-model",
+        "primary_artifacts": [],
+        "messages": [
+            {
+                "role": "assistant",
+                "metadata": {
+                    "design_studio": {
+                        "candidate_directions": [
+                            {"id": "direction-b", "label": "Direction B"},
+                        ],
+                    },
+                },
+            },
+        ],
+    }
+    updated = {
+        **conversation,
+        "session_config": {
+            "design_target": "web_app",
+            "studio_goal": "iterate",
+            "approved_direction_id": "direction-b",
+        },
+    }
+
+    app.dependency_overrides[auth.get_current_user_id] = lambda: "test_user"
+    try:
+        with patch("backend.storage.get_conversation", new_callable=AsyncMock) as mock_get_conversation, \
+             patch("backend.storage.update_conversation_context", new_callable=AsyncMock) as mock_update_context:
+            mock_get_conversation.return_value = conversation
+            mock_update_context.return_value = updated
+
+            response = await async_client.post(
+                "/api/conversations/conv-approve/design-studio/approved-direction",
+                json={"direction_id": " direction-b "},
+            )
+
+            assert response.status_code == 200
+            payload = response.json()
+            assert payload["session_config"] == updated["session_config"]
+            mock_update_context.assert_awaited_once_with(
+                "conv-approve",
+                "test_user",
+                session_config={
+                    "design_target": "web_app",
+                    "studio_goal": "iterate",
+                    "approved_direction_id": "direction-b",
+                },
+            )
+    finally:
+        app.dependency_overrides = {}
+
+
+@pytest.mark.asyncio
+async def test_approve_design_direction_rejects_non_design_sessions(async_client):
+    conversation = {
+        "id": "conv-general",
+        "framework": "standard",
+        "session_type": "general",
+        "session_config": {},
+        "council_models": ["model-a"],
+        "chairman_model": "chair-model",
+        "primary_artifacts": [],
+        "messages": [],
+    }
+
+    app.dependency_overrides[auth.get_current_user_id] = lambda: "test_user"
+    try:
+        with patch("backend.storage.get_conversation", new_callable=AsyncMock) as mock_get_conversation, \
+             patch("backend.storage.update_conversation_context", new_callable=AsyncMock) as mock_update_context:
+            mock_get_conversation.return_value = conversation
+
+            response = await async_client.post(
+                "/api/conversations/conv-general/design-studio/approved-direction",
+                json={"direction_id": "direction-a"},
+            )
+
+            assert response.status_code == 400
+            mock_update_context.assert_not_awaited()
+    finally:
+        app.dependency_overrides = {}
+
+
+@pytest.mark.asyncio
+async def test_approve_design_direction_rejects_unknown_candidate(async_client):
+    conversation = {
+        "id": "conv-approve",
+        "framework": "standard",
+        "session_type": "design_studio",
+        "session_config": {
+            "design_target": "web_app",
+            "studio_goal": "compare",
+            "approved_direction_id": None,
+        },
+        "council_models": ["model-a"],
+        "chairman_model": "chair-model",
+        "primary_artifacts": [],
+        "messages": [
+            {
+                "role": "assistant",
+                "metadata": {
+                    "design_studio": {
+                        "candidate_directions": [
+                            {"id": "direction-a", "label": "Direction A"},
+                        ],
+                    },
+                },
+            },
+        ],
+    }
+
+    app.dependency_overrides[auth.get_current_user_id] = lambda: "test_user"
+    try:
+        with patch("backend.storage.get_conversation", new_callable=AsyncMock) as mock_get_conversation, \
+             patch("backend.storage.update_conversation_context", new_callable=AsyncMock) as mock_update_context:
+            mock_get_conversation.return_value = conversation
+
+            response = await async_client.post(
+                "/api/conversations/conv-approve/design-studio/approved-direction",
+                json={"direction_id": "direction-b"},
+            )
+
+            assert response.status_code == 400
+            mock_update_context.assert_not_awaited()
+    finally:
+        app.dependency_overrides = {}
+
+
+@pytest.mark.asyncio
 async def test_send_message_design_studio_includes_session_context(async_client):
     conversation = {
         "id": "conv-design-studio",


### PR DESCRIPTION
## Summary
- Add an authenticated Design Studio approval endpoint that persists an approved candidate direction and switches the session goal to iterate.
- Add Approve Direction actions to Design Studio variant cards, including approved badges and disabled approved state.
- Feed the persisted conversation session config back into message rendering so approvals stay visible after reload and future prompts retain the chosen direction through the existing session workspace context.
- Validate approvals against known Design Studio candidate ids when candidate metadata exists.

## Validation
- cd frontend && npm run test
- cd frontend && npm run lint
- cd frontend && npm run build
- uv run pytest tests/test_api.py tests/test_validation.py tests/test_storage.py -q
- uv run pytest -q
- Browser QA approved a Design Studio direction, verified the UI showed Approved for Refinement, header switched to Iterate, console stayed clean, and storage persisted approved_direction_id direction-b.

## Review
- Pre-landing review found no actionable issues.
- Security pass found no unsafe HTML rendering, credential handling, shell execution, or unvalidated arbitrary direction approval after candidate-id validation was added.
