### PR TITLE
AR-105: Export Design Studio handoffs

### DIFF
--- a/backend/design_studio.py
+++ b/backend/design_studio.py
@@ -29,6 +29,16 @@ HANDOFF_SECTION_SPECS = [
         "aliases": ("handoff notes", "handoff", "implementation notes"),
     },
     {
+        "key": "state_notes",
+        "label": "State Notes",
+        "aliases": ("state notes", "interaction states", "empty loading and error states", "states"),
+    },
+    {
+        "key": "platform_constraints",
+        "label": "Platform Constraints",
+        "aliases": ("platform constraints", "platform notes", "constraints"),
+    },
+    {
         "key": "open_questions",
         "label": "Open Questions",
         "aliases": ("open questions", "questions", "risks and open questions"),
@@ -84,7 +94,7 @@ def _split_markdown_sections(text: str) -> Dict[str, str]:
         heading_match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", line)
         bold_heading_match = re.match(r"^\s{0,3}\*\*(.+?)\*\*:?\s*$", line)
         plain_heading_match = re.match(
-            r"^\s{0,3}(Selected Direction|Recommended Direction|Recommendation|Rationale|Why This Direction|Decision Rationale|Component Map|Component Mapping|Implementation Map|Screens and Components|Handoff Notes|Handoff|Implementation Notes|Open Questions|Questions|Risks and Open Questions):?\s*$",
+            r"^\s{0,3}(Selected Direction|Recommended Direction|Recommendation|Rationale|Why This Direction|Decision Rationale|Component Map|Component Mapping|Implementation Map|Screens and Components|Handoff Notes|Handoff|Implementation Notes|State Notes|Interaction States|Empty Loading and Error States|States|Platform Constraints|Platform Notes|Constraints|Open Questions|Questions|Risks and Open Questions):?\s*$",
             line,
             flags=re.IGNORECASE,
         )

--- a/backend/export.py
+++ b/backend/export.py
@@ -14,6 +14,185 @@ from .session_context import (
     normalize_session_config,
 )
 
+
+DESIGN_MD_SECTION_KEYS = [
+    ("selected_direction", "Chosen Direction"),
+    ("rationale", "Why This Direction Won"),
+    ("component_map", "Component Map"),
+    ("state_notes", "State Notes"),
+    ("platform_constraints", "Platform Constraints"),
+    ("handoff_notes", "Implementation Notes"),
+    ("open_questions", "Open Questions"),
+]
+
+
+def _clean_markdown_value(value) -> str:
+    return str(value or "").strip()
+
+
+def _latest_design_studio_metadata(conversation: dict) -> dict:
+    for message in reversed(conversation.get("messages") or []):
+        if not isinstance(message, dict):
+            continue
+        metadata = message.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        design_studio = metadata.get("design_studio")
+        if isinstance(design_studio, dict):
+            return design_studio
+    return {}
+
+
+def _latest_ready_design_handoff(conversation: dict, approved_direction_id: str) -> dict:
+    fallback = {}
+    for message in reversed(conversation.get("messages") or []):
+        if not isinstance(message, dict):
+            continue
+        metadata = message.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        design_studio = metadata.get("design_studio")
+        if not isinstance(design_studio, dict):
+            continue
+        handoff = design_studio.get("handoff")
+        if not isinstance(handoff, dict) or handoff.get("status") != "ready":
+            continue
+        if not fallback:
+            fallback = handoff
+        if approved_direction_id and handoff.get("selected_direction_id") == approved_direction_id:
+            return handoff
+    return {} if approved_direction_id else fallback
+
+
+def _section_from_handoff(handoff: dict, key: str) -> dict:
+    direct = handoff.get(key)
+    if isinstance(direct, dict):
+        return {
+            "content": _clean_markdown_value(direct.get("content")),
+            "items": direct.get("items") if isinstance(direct.get("items"), list) else [],
+        }
+
+    for item in handoff.get("sections") or []:
+        if isinstance(item, dict) and item.get("key") == key:
+            return {
+                "content": _clean_markdown_value(item.get("content")),
+                "items": item.get("items") if isinstance(item.get("items"), list) else [],
+            }
+    return {"content": "", "items": []}
+
+
+def _append_design_section(lines: list[str], title: str, section: dict, fallback: str = "") -> None:
+    content = _clean_markdown_value(section.get("content")) or fallback
+    items = [
+        _clean_markdown_value(item)
+        for item in (section.get("items") or [])
+        if _clean_markdown_value(item)
+    ]
+
+    lines.append(f"## {title}\n\n")
+    if items:
+        for item in items:
+            lines.append(f"- {item}\n")
+        lines.append("\n")
+    elif content:
+        lines.append(f"{content}\n\n")
+    else:
+        lines.append("_Not captured._\n\n")
+
+
+def _selected_direction_ref(design_studio: dict, handoff: dict, approved_direction_id: str) -> dict:
+    if approved_direction_id:
+        for direction in design_studio.get("candidate_directions") or []:
+            if isinstance(direction, dict) and direction.get("id") == approved_direction_id:
+                return direction
+
+    selected_ref = handoff.get("selected_direction_ref")
+    if (
+        isinstance(selected_ref, dict)
+        and selected_ref
+        and (not approved_direction_id or selected_ref.get("id") == approved_direction_id)
+    ):
+        return selected_ref
+
+    for direction in design_studio.get("candidate_directions") or []:
+        if isinstance(direction, dict) and direction.get("id") == approved_direction_id:
+            return direction
+    return {}
+
+
+def export_design_handoff_to_markdown(conversation: dict) -> str:
+    """Export the approved Design Studio direction as a compact DESIGN.md handoff."""
+    if not isinstance(conversation, dict):
+        conversation = {}
+
+    session_config = normalize_session_config(
+        conversation.get("session_config"),
+        session_type=conversation.get("session_type"),
+    )
+    approved_direction_id = session_config.get("approved_direction_id") or ""
+    design_studio = _latest_design_studio_metadata(conversation)
+    handoff = _latest_ready_design_handoff(conversation, approved_direction_id)
+    selected_ref = _selected_direction_ref(design_studio, handoff, approved_direction_id)
+    selected_direction_id = approved_direction_id or handoff.get("selected_direction_id") or selected_ref.get("id") or ""
+
+    lines = []
+    lines.append("# DESIGN.md\n\n")
+    lines.append(f"**Conversation:** {conversation.get('title') or 'Conversation'}\n")
+    lines.append(f"**Generated From:** {conversation.get('id') or ''}\n")
+    lines.append(f"**Date:** {conversation.get('created_at') or ''}\n")
+    lines.append(f"**Design Target:** {get_design_target_label(session_config.get('design_target'))}\n")
+    lines.append(f"**Studio Goal:** {get_studio_goal_label(session_config.get('studio_goal'))}\n")
+    if selected_direction_id:
+        lines.append(f"**Approved Direction:** {selected_direction_id}\n")
+    lines.append("\n")
+
+    primary_artifacts = normalize_primary_artifacts(conversation.get("primary_artifacts"))
+    lines.append("## Source Artifacts\n\n")
+    if primary_artifacts:
+        for artifact in primary_artifacts:
+            label = artifact.get("label") or artifact.get("filename") or "Artifact"
+            kind = artifact.get("kind") or "artifact"
+            status = artifact.get("status") or "ready"
+            lines.append(f"- {label} ({kind}, {status})\n")
+        lines.append("\n")
+    else:
+        lines.append("_No primary artifacts attached._\n\n")
+
+    selected_summary = _clean_markdown_value(selected_ref.get("summary"))
+    if selected_ref:
+        ref_lines = []
+        label = _clean_markdown_value(selected_ref.get("label"))
+        source_model = _clean_markdown_value(selected_ref.get("source_model"))
+        if label:
+            ref_lines.append(label)
+        if source_model:
+            ref_lines.append(f"Source model: {source_model}")
+        if selected_summary:
+            ref_lines.append(selected_summary)
+        fallback_selected = "\n\n".join(ref_lines)
+    else:
+        fallback_selected = selected_direction_id
+
+    for key, title in DESIGN_MD_SECTION_KEYS:
+        fallback = fallback_selected if key == "selected_direction" else ""
+        _append_design_section(lines, title, _section_from_handoff(handoff, key), fallback=fallback)
+
+    comparison = design_studio.get("comparison") if isinstance(design_studio, dict) else {}
+    ranked_directions = comparison.get("ranked_directions") if isinstance(comparison, dict) else []
+    if isinstance(ranked_directions, list) and ranked_directions:
+        lines.append("## Decision Trace\n\n")
+        for item in ranked_directions[:5]:
+            if not isinstance(item, dict):
+                continue
+            direction_id = item.get("direction_id") or "direction"
+            rank = item.get("rank") or "n/a"
+            average_rank = item.get("average_rank")
+            suffix = f", average rank {average_rank}" if average_rank is not None else ""
+            lines.append(f"- Rank {rank}: {direction_id}{suffix}\n")
+        lines.append("\n")
+
+    return "".join(lines)
+
 def export_to_markdown(conversation: dict) -> str:
     """
     Export conversation to Markdown format.

--- a/backend/main.py
+++ b/backend/main.py
@@ -657,7 +657,7 @@ async def export_conversation(
     format: str = "md",
     user_id: str = Depends(auth.get_current_user_id)
 ):
-    """Export a conversation to Markdown or PDF."""
+    """Export a conversation to Markdown, PDF, or a compact Design Studio handoff."""
     conversation = await storage.get_conversation(conversation_id, user_id)
     if not conversation:
         raise HTTPException(status_code=404, detail="Conversation not found")
@@ -669,6 +669,15 @@ async def export_conversation(
             media_type="text/markdown",
             headers={"Content-Disposition": f"attachment; filename=conversation_{conversation_id}.md"}
         )
+    elif format == "design_md":
+        if normalize_session_type(conversation.get("session_type")) != "design_studio":
+            raise HTTPException(status_code=400, detail="DESIGN.md export is only available for Design Studio sessions.")
+        content = export.export_design_handoff_to_markdown(conversation)
+        return StreamingResponse(
+            io.StringIO(content),
+            media_type="text/markdown",
+            headers={"Content-Disposition": "attachment; filename=DESIGN.md"}
+        )
     elif format == "pdf":
         content_bytes = export.export_to_pdf(conversation)
         return StreamingResponse(
@@ -677,7 +686,7 @@ async def export_conversation(
             headers={"Content-Disposition": f"attachment; filename=conversation_{conversation_id}.pdf"}
         )
     else:
-        raise HTTPException(status_code=400, detail="Invalid format. Use 'md' or 'pdf'.")
+        raise HTTPException(status_code=400, detail="Invalid format. Use 'md', 'design_md', or 'pdf'.")
 
 
 @app.get("/api/conversations", response_model=List[ConversationMetadata])

--- a/backend/session_templates.py
+++ b/backend/session_templates.py
@@ -6,7 +6,8 @@ from typing import Dict, List, Optional
 
 DESIGN_STUDIO_DELIVERABLE_INSTRUCTION = (
     "Use sections titled Candidate Directions, Comparison, Recommended Direction, "
-    "Selected Direction, Rationale, Component Map, Handoff Notes, and Open Questions. "
+    "Selected Direction, Rationale, Component Map, Handoff Notes, State Notes, "
+    "Platform Constraints, and Open Questions. "
     "Keep section headings exact so the app can render a structured design handoff."
 )
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -396,7 +396,9 @@ export const api = {
     // Filename is usually in Content-Disposition header, but we can guess or let browser handle it
     // Or we can try to extract it from headers if needed.
     // For simplicity, we just trigger click.
-    a.download = `conversation_${conversationId}.${format === 'md' ? 'md' : 'pdf'}`;
+    a.download = format === 'design_md'
+      ? 'DESIGN.md'
+      : `conversation_${conversationId}.${format === 'md' ? 'md' : 'pdf'}`;
     document.body.appendChild(a);
     a.click();
     window.URL.revokeObjectURL(url);

--- a/frontend/src/components/ChatHeader.jsx
+++ b/frontend/src/components/ChatHeader.jsx
@@ -4,7 +4,7 @@ import { api } from '../api';
 import { logger } from '@/lib/logger';
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Download, Link as LinkIcon, FileText, Check } from "lucide-react";
+import { Download, Link as LinkIcon, FileText, Check, ClipboardList } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -45,6 +45,7 @@ const ChatHeader = memo(({
   const normalizedSessionConfig = normalizeSessionConfig(sessionType, sessionConfig);
   const specialistTemplateLabel = getSpecialistTemplateLabel(specialistTemplateId);
   const chairmanLabel = chairmanModel || 'Auto';
+  const canExportDesignHandoff = sessionType === 'design_studio' && Boolean(normalizedSessionConfig.approved_direction_id);
 
   const handleExport = async (format) => {
     if (!conversationId) return;
@@ -113,6 +114,17 @@ const ChatHeader = memo(({
             </TooltipTrigger>
             <TooltipContent>Export to Markdown</TooltipContent>
           </Tooltip>
+
+          {canExportDesignHandoff && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon" onClick={() => handleExport('design_md')}>
+                  <ClipboardList className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Export DESIGN.md</TooltipContent>
+            </Tooltip>
+          )}
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/frontend/src/components/CouncilMessageBlock.jsx
+++ b/frontend/src/components/CouncilMessageBlock.jsx
@@ -331,7 +331,14 @@ const DiffTabContent = memo(({ diffData, rubricHotspots }) => {
 
 DiffTabContent.displayName = 'DiffTabContent';
 
-const DESIGN_HANDOFF_KEYS = ['rationale', 'component_map', 'handoff_notes', 'open_questions'];
+const DESIGN_HANDOFF_KEYS = [
+  'rationale',
+  'component_map',
+  'handoff_notes',
+  'state_notes',
+  'platform_constraints',
+  'open_questions',
+];
 
 const getHandoffSection = (handoff, key) => {
   const directSection = handoff?.[key];

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,6 +33,71 @@ async def test_health_check_public(async_client):
     assert response.json()["status"] == "ok"
 
 @pytest.mark.asyncio
+async def test_export_design_handoff_markdown(async_client):
+    """Test Design Studio conversations can export a compact DESIGN.md handoff."""
+    conversation = {
+        "id": "conv-design-export",
+        "title": "Design Export",
+        "session_type": "design_studio",
+        "session_config": {
+            "design_target": "web_app",
+            "studio_goal": "iterate",
+            "approved_direction_id": "direction-a",
+        },
+        "messages": [
+            {
+                "role": "assistant",
+                "metadata": {
+                    "design_studio": {
+                        "candidate_directions": [
+                            {"id": "direction-a", "label": "Direction A", "summary": "Focused dashboard."}
+                        ],
+                        "handoff": {
+                            "status": "ready",
+                            "selected_direction_id": "direction-a",
+                            "selected_direction": {
+                                "label": "Selected Direction",
+                                "content": "Direction A is approved.",
+                                "items": [],
+                            },
+                        },
+                    }
+                },
+            }
+        ],
+    }
+
+    async def mock_get_conversation(*args, **kwargs):
+        return conversation
+
+    app.dependency_overrides[auth.get_current_user_id] = lambda: "test_user"
+    try:
+        with patch("backend.storage.get_conversation", side_effect=mock_get_conversation):
+            response = await async_client.get("/api/conversations/conv-design-export/export?format=design_md")
+        assert response.status_code == 200
+        assert response.headers["content-disposition"] == "attachment; filename=DESIGN.md"
+        assert "# DESIGN.md" in response.text
+        assert "**Approved Direction:** direction-a" in response.text
+        assert "Direction A is approved." in response.text
+    finally:
+        app.dependency_overrides = {}
+
+@pytest.mark.asyncio
+async def test_export_design_handoff_rejects_non_design_session(async_client):
+    """Test DESIGN.md export remains scoped to Design Studio sessions."""
+    async def mock_get_conversation(*args, **kwargs):
+        return {"id": "conv-general", "session_type": "general", "messages": []}
+
+    app.dependency_overrides[auth.get_current_user_id] = lambda: "test_user"
+    try:
+        with patch("backend.storage.get_conversation", side_effect=mock_get_conversation):
+            response = await async_client.get("/api/conversations/conv-general/export?format=design_md")
+        assert response.status_code == 400
+        assert response.json()["detail"] == "DESIGN.md export is only available for Design Studio sessions."
+    finally:
+        app.dependency_overrides = {}
+
+@pytest.mark.asyncio
 async def test_list_models_mocked(async_client):
     """Test listing models uses the mocked OpenRouter auth."""
     mock_models = [

--- a/tests/test_design_studio.py
+++ b/tests/test_design_studio.py
@@ -93,6 +93,14 @@ Direction B is the selected direction.
 ## Handoff Notes
 Use the existing card primitives and keep empty states explicit.
 
+## State Notes
+- Empty state should invite users to add their first variant.
+- Loading state should preserve the comparison frame.
+
+## Platform Constraints
+- Web needs keyboard-first navigation.
+- iOS should keep primary actions thumb-reachable.
+
 ## Open Questions
 - Should the workspace include saved variants in v1?""",
     }
@@ -118,6 +126,14 @@ Use the existing card primitives and keep empty states explicit.
         "Workspace: editorial layout with preview pane.",
     ]
     assert handoff["handoff_notes"]["content"] == "Use the existing card primitives and keep empty states explicit."
+    assert handoff["state_notes"]["items"] == [
+        "Empty state should invite users to add their first variant.",
+        "Loading state should preserve the comparison frame.",
+    ]
+    assert handoff["platform_constraints"]["items"] == [
+        "Web needs keyboard-first navigation.",
+        "iOS should keep primary actions thumb-reachable.",
+    ]
     assert handoff["open_questions"]["items"] == [
         "Should the workspace include saved variants in v1?",
     ]
@@ -126,6 +142,8 @@ Use the existing card primitives and keep empty states explicit.
         "rationale",
         "component_map",
         "handoff_notes",
+        "state_notes",
+        "platform_constraints",
         "open_questions",
     ]
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -46,6 +46,160 @@ def test_markdown_export():
     assert "## User" in md
     assert "Hello" in md
 
+def test_design_handoff_markdown_export_uses_approved_direction():
+    conversation = {
+        "id": "conv-design",
+        "title": "Checkout Redesign",
+        "created_at": "2026-04-24",
+        "session_type": "design_studio",
+        "session_config": {
+            "design_target": "mixed",
+            "studio_goal": "iterate",
+            "approved_direction_id": "direction-b",
+        },
+        "primary_artifacts": [
+            {"label": "checkout.png", "kind": "image", "status": "ready"},
+        ],
+        "messages": [
+            {
+                "role": "assistant",
+                "metadata": {
+                    "design_studio": {
+                        "candidate_directions": [
+                            {
+                                "id": "direction-b",
+                                "label": "Direction B",
+                                "source_model": "model-b",
+                                "summary": "Calmer checkout hierarchy.",
+                            }
+                        ],
+                        "comparison": {
+                            "ranked_directions": [
+                                {"direction_id": "direction-b", "rank": 1, "average_rank": 1.0}
+                            ]
+                        },
+                        "handoff": {
+                            "status": "ready",
+                            "selected_direction_id": "direction-b",
+                            "selected_direction_ref": {
+                                "id": "direction-b",
+                                "label": "Direction B",
+                                "source_model": "model-b",
+                                "summary": "Calmer checkout hierarchy.",
+                            },
+                            "selected_direction": {
+                                "label": "Selected Direction",
+                                "content": "Direction B is approved.",
+                                "items": [],
+                            },
+                            "rationale": {
+                                "label": "Rationale",
+                                "content": "- Stronger purchase clarity.",
+                                "items": ["Stronger purchase clarity."],
+                            },
+                            "component_map": {
+                                "label": "Component Map",
+                                "content": "- Order summary: sticky confirmation module.",
+                                "items": ["Order summary: sticky confirmation module."],
+                            },
+                            "state_notes": {
+                                "label": "State Notes",
+                                "content": "- Preserve totals during loading.",
+                                "items": ["Preserve totals during loading."],
+                            },
+                            "platform_constraints": {
+                                "label": "Platform Constraints",
+                                "content": "- iOS actions stay thumb-reachable.",
+                                "items": ["iOS actions stay thumb-reachable."],
+                            },
+                            "handoff_notes": {
+                                "label": "Handoff Notes",
+                                "content": "Use existing checkout primitives.",
+                                "items": [],
+                            },
+                            "open_questions": {
+                                "label": "Open Questions",
+                                "content": "- Confirm promo code placement.",
+                                "items": ["Confirm promo code placement."],
+                            },
+                        },
+                    },
+                },
+            }
+        ],
+    }
+
+    md = export.export_design_handoff_to_markdown(conversation)
+
+    assert md.startswith("# DESIGN.md")
+    assert "**Approved Direction:** direction-b" in md
+    assert "## Chosen Direction" in md
+    assert "Direction B is approved." in md
+    assert "## Why This Direction Won" in md
+    assert "- Stronger purchase clarity." in md
+    assert "## Component Map" in md
+    assert "## State Notes" in md
+    assert "- Preserve totals during loading." in md
+    assert "## Platform Constraints" in md
+    assert "- iOS actions stay thumb-reachable." in md
+    assert "## Decision Trace" in md
+
+def test_design_handoff_markdown_export_ignores_stale_selected_handoff():
+    conversation = {
+        "id": "conv-design-stale",
+        "title": "Checkout Redesign",
+        "session_type": "design_studio",
+        "session_config": {
+            "design_target": "web_app",
+            "studio_goal": "iterate",
+            "approved_direction_id": "direction-a",
+        },
+        "messages": [
+            {
+                "role": "assistant",
+                "metadata": {
+                    "design_studio": {
+                        "candidate_directions": [
+                            {
+                                "id": "direction-a",
+                                "label": "Direction A",
+                                "source_model": "model-a",
+                                "summary": "Dense operational dashboard.",
+                            },
+                            {
+                                "id": "direction-b",
+                                "label": "Direction B",
+                                "source_model": "model-b",
+                                "summary": "Calmer editorial layout.",
+                            },
+                        ],
+                        "handoff": {
+                            "status": "ready",
+                            "selected_direction_id": "direction-b",
+                            "selected_direction_ref": {
+                                "id": "direction-b",
+                                "label": "Direction B",
+                                "summary": "Calmer editorial layout.",
+                            },
+                            "selected_direction": {
+                                "label": "Selected Direction",
+                                "content": "Direction B is recommended.",
+                                "items": [],
+                            },
+                        },
+                    },
+                },
+            }
+        ],
+    }
+
+    md = export.export_design_handoff_to_markdown(conversation)
+
+    assert "**Approved Direction:** direction-a" in md
+    assert "Direction A" in md
+    assert "Dense operational dashboard." in md
+    assert "Direction B is recommended." not in md
+
 def test_export_empty_conversation():
     """Test exporting an empty conversation dictionary."""
     conv = {}


### PR DESCRIPTION
## Summary
- add authenticated `design_md` export format that downloads a compact `DESIGN.md` for Design Studio sessions
- include approved direction, source artifacts, rationale, component map, state notes, platform constraints, implementation notes, open questions, and decision trace
- expose the export control for approved Design Studio sessions and keep standard Markdown/PDF exports unchanged

## Validation
- `uv run pytest -q` -> 191 passed, 4 existing OpenRouter mock warnings
- `cd frontend && npm run lint` -> passed
- `cd frontend && npm run test -- --run` -> 32 passed
- `cd frontend && npm run build` -> passed, existing large chunk warning
- Browser QA: approved Design Studio session shows the DESIGN.md export control; clicking it requests `format=design_md`; direct payload verified via curl; no console errors after authenticated reload/click
