### PR TITLE
AR-106: Harden Design Studio backend contracts

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -865,7 +865,26 @@ async def test_send_message_stream_design_studio_emits_structured_stage_metadata
         yield {"model": "model-b", "response": "Direction B\nCalmer editorial layout."}
 
     async def mock_stage3_stream(*args, **kwargs):
-        yield "Ship Direction B."
+        yield """## Selected Direction
+Direction B is recommended.
+
+## Rationale
+- Calmer hierarchy is easier to scan.
+
+## Component Map
+- Workspace: comparison-first layout.
+
+## Handoff Notes
+Use existing workspace primitives.
+
+## State Notes
+- Empty state prompts users to generate variants.
+
+## Platform Constraints
+- Web keeps keyboard navigation visible.
+
+## Open Questions
+- Should saved variants ship in v1?"""
 
     app.dependency_overrides[auth.get_current_user_id] = lambda: "test_user"
     try:
@@ -909,19 +928,39 @@ async def test_send_message_stream_design_studio_emits_structured_stage_metadata
                 "direction-b",
             ]
             assert stage1_design["comparison"]["status"] == "pending"
+            assert stage1_complete["metadata"]["session_config"] == conversation["session_config"]
 
             stage2_design = stage2_complete["metadata"]["design_studio"]
             assert stage2_design["comparison"]["status"] == "complete"
             assert stage2_design["comparison"]["ranked_directions"][0]["direction_id"] == "direction-b"
+            assert stage2_design["comparison"]["rubric_summaries"][0]["direction_id"] == "direction-b"
+            assert stage2_design["comparison"]["judge_results"][0]["ranked_directions"][0]["direction_id"] == "direction-b"
             assert stage2_design["selected_direction_id"] == "direction-b"
 
             stage3_design = stage3_complete["metadata"]["design_studio"]
             assert stage3_design["handoff"]["status"] == "ready"
             assert stage3_design["handoff"]["selected_direction_id"] == "direction-b"
+            assert [section["key"] for section in stage3_design["handoff"]["sections"]] == [
+                "selected_direction",
+                "rationale",
+                "component_map",
+                "handoff_notes",
+                "state_notes",
+                "platform_constraints",
+                "open_questions",
+            ]
+            assert stage3_design["handoff"]["state_notes"]["items"] == [
+                "Empty state prompts users to generate variants."
+            ]
+            assert stage3_design["handoff"]["platform_constraints"]["items"] == [
+                "Web keeps keyboard navigation visible."
+            ]
 
             saved_metadata = mock_add_assistant_message.await_args.args[5]
             assert saved_metadata["design_studio"]["selected_direction_id"] == "direction-b"
             assert saved_metadata["design_studio"]["handoff"]["status"] == "ready"
+            assert saved_metadata["session_type"] == "design_studio"
+            assert saved_metadata["session_config"] == conversation["session_config"]
     finally:
         app.dependency_overrides = {}
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,59 @@
+from sqlalchemy import Column, DateTime, JSON, MetaData, String, Table, create_engine, inspect
+
+from backend.database import _ensure_conversation_schema
+
+
+def test_ensure_conversation_schema_adds_design_studio_columns_to_legacy_table():
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    Table(
+        "conversations",
+        metadata,
+        Column("id", String, primary_key=True),
+        Column("user_id", String, nullable=False),
+        Column("title", String),
+        Column("created_at", DateTime),
+        Column("framework", String),
+        Column("council_models", JSON),
+        Column("chairman_model", String),
+        Column("messages", JSON),
+        Column("origin", String),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _ensure_conversation_schema(connection)
+
+    columns = {column["name"] for column in inspect(engine).get_columns("conversations")}
+
+    assert "session_type" in columns
+    assert "specialist_template_id" in columns
+    assert "execution_mode" in columns
+    assert "session_config" in columns
+    assert "primary_artifacts" in columns
+
+
+def test_ensure_conversation_schema_is_idempotent_for_current_table():
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    Table(
+        "conversations",
+        metadata,
+        Column("id", String, primary_key=True),
+        Column("user_id", String, nullable=False),
+        Column("session_type", String),
+        Column("specialist_template_id", String),
+        Column("execution_mode", String),
+        Column("session_config", JSON),
+        Column("primary_artifacts", JSON),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        _ensure_conversation_schema(connection)
+        _ensure_conversation_schema(connection)
+
+    columns = [column["name"] for column in inspect(engine).get_columns("conversations")]
+
+    assert columns.count("session_config") == 1
+    assert columns.count("primary_artifacts") == 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -133,3 +133,39 @@ async def test_design_studio_session_config_persists_in_file_storage():
     )
     assert reset["session_type"] == "general"
     assert reset["session_config"] == {}
+
+def test_legacy_file_conversation_hydrates_design_studio_defaults():
+    conversation = storage._hydrate_conversation_dict({
+        "id": "legacy-design",
+        "user_id": "user_design",
+        "session_type": "design_studio",
+        "session_config": {
+            "design_target": "both",
+            "studio_goal": "compare",
+            "approved_direction_id": "  direction-b  ",
+        },
+    })
+
+    assert conversation["session_type"] == "design_studio"
+    assert conversation["session_config"] == {
+        "design_target": "mixed",
+        "studio_goal": "compare",
+        "approved_direction_id": "direction-b",
+    }
+    assert conversation["primary_artifacts"] == []
+    assert conversation["execution_mode"] == "disabled"
+
+def test_legacy_non_design_conversation_drops_stale_design_config():
+    conversation = storage._hydrate_conversation_dict({
+        "id": "legacy-general",
+        "user_id": "user_general",
+        "session_type": "visual_review",
+        "session_config": {
+            "design_target": "ios_app",
+            "studio_goal": "handoff",
+            "approved_direction_id": "direction-a",
+        },
+    })
+
+    assert conversation["session_type"] == "visual_review"
+    assert conversation["session_config"] == {}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -111,6 +111,22 @@ def test_design_studio_legacy_both_target_normalizes_to_mixed():
     )
     assert req.session_config["design_target"] == "mixed"
 
+def test_design_studio_invalid_config_values_fall_back_to_defaults():
+    """Test malformed design studio config cannot leak into stored contracts."""
+    req = CreateConversationRequest(
+        session_type="design_studio",
+        session_config={
+            "design_target": "desktop_app",
+            "studio_goal": "storyboard",
+            "approved_direction_id": 123,
+        },
+    )
+    assert req.session_config == {
+        "design_target": "web_app",
+        "studio_goal": "generate",
+        "approved_direction_id": None,
+    }
+
 def test_non_design_sessions_clear_session_config():
     """Test that non-design sessions do not retain design studio config."""
     req = CreateConversationRequest(


### PR DESCRIPTION
## Summary
- add in-memory schema migration tests for legacy conversation tables gaining session config and artifact columns
- add legacy file hydration tests for Design Studio defaults and non-design config cleanup
- strengthen Design Studio SSE metadata assertions for candidate IDs, rankings, rubrics, judge results, handoff section keys, state notes, and platform constraints
- add invalid Design Studio config normalization coverage while preserving Visual Review and Code Review regression checks

## Validation
- `uv run pytest tests/test_validation.py tests/test_storage.py tests/test_database.py tests/test_api.py::test_send_message_stream_design_studio_emits_structured_stage_metadata tests/test_api.py::test_send_message_stream_design_studio_with_image_findings_enables_critique_surface tests/test_api.py::test_send_message_code_review_returns_execution_metadata -q` -> 29 passed
- `uv run pytest -q` -> 196 passed, 4 existing OpenRouter mock warnings

## Review/Security
- test-only change; no production runtime behavior, network access, credential handling, or persistent file-write behavior changed
