### PR TITLE
AR-107: Cover Design Studio frontend states

### DIFF
--- a/frontend/src/components/CouncilMessageBlock.jsx
+++ b/frontend/src/components/CouncilMessageBlock.jsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { AlertTriangle, Trophy, Crown, BrainCircuit, CheckCircle2, FileImage, GitCompareArrows, PauseCircle, RefreshCw, RotateCcw, Wrench, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { buildDesignStudioWorkspaceView, formatDesignStudioScore } from "@/lib/designStudioWorkspace";
+import { buildDesignStudioHandoffView } from "@/lib/designStudioHandoff";
 import { buildVisualReviewSurface } from "@/lib/visualReviewSurface";
 import VisualReviewPanel from './VisualReviewPanel';
 
@@ -331,41 +332,6 @@ const DiffTabContent = memo(({ diffData, rubricHotspots }) => {
 
 DiffTabContent.displayName = 'DiffTabContent';
 
-const DESIGN_HANDOFF_KEYS = [
-  'rationale',
-  'component_map',
-  'handoff_notes',
-  'state_notes',
-  'platform_constraints',
-  'open_questions',
-];
-
-const getHandoffSection = (handoff, key) => {
-  const directSection = handoff?.[key];
-  if (directSection && typeof directSection === 'object') {
-    return {
-      label: directSection.label || key,
-      content: typeof directSection.content === 'string' ? directSection.content : '',
-      items: Array.isArray(directSection.items) ? directSection.items : EMPTY_LIST,
-    };
-  }
-
-  const section = Array.isArray(handoff?.sections)
-    ? handoff.sections.find((item) => item?.key === key)
-    : null;
-  if (!section) return null;
-
-  return {
-    label: section.label || key,
-    content: typeof section.content === 'string' ? section.content : '',
-    items: Array.isArray(section.items) ? section.items : EMPTY_LIST,
-  };
-};
-
-const hasHandoffSectionContent = (section) => (
-  Boolean(section && (section.content.trim() || section.items.length > 0))
-);
-
 const HandoffSectionContent = ({ section }) => {
   if (!section) return null;
   if (section.items.length > 0) {
@@ -394,19 +360,21 @@ const HandoffSectionContent = ({ section }) => {
 const DesignStudioHandoffPanel = memo(({ handoff }) => {
   if (!handoff || handoff.status !== 'ready') return null;
 
-  const selectedRef = handoff.selected_direction_ref && typeof handoff.selected_direction_ref === 'object'
-    ? handoff.selected_direction_ref
-    : null;
-  const selectedSection = getHandoffSection(handoff, 'selected_direction');
-  const sections = DESIGN_HANDOFF_KEYS
-    .map((key) => getHandoffSection(handoff, key))
-    .filter(hasHandoffSectionContent);
-  const hasContent = Boolean(selectedRef) || hasHandoffSectionContent(selectedSection) || sections.length > 0;
+  const {
+    selectedRef,
+    selectedSection,
+    sections,
+    hasContent,
+  } = buildDesignStudioHandoffView(handoff);
 
   if (!hasContent) return null;
 
   return (
-    <div className="mb-5 overflow-hidden rounded-xl border border-sky-500/20 bg-gradient-to-br from-sky-500/10 via-card to-emerald-500/10">
+    <div
+      className="mb-5 overflow-hidden rounded-xl border border-sky-500/20 bg-gradient-to-br from-sky-500/10 via-card to-emerald-500/10"
+      role="region"
+      aria-label="Structured design handoff"
+    >
       <div className="border-b border-sky-500/10 px-4 py-3">
         <div className="flex items-center justify-between gap-3 flex-wrap">
           <div>
@@ -443,7 +411,7 @@ const DesignStudioHandoffPanel = memo(({ handoff }) => {
           </div>
         )}
 
-        {hasHandoffSectionContent(selectedSection) && (
+        {selectedSection && (selectedSection.content.trim() || selectedSection.items.length > 0) && (
           <div className="rounded-lg border bg-background/60 p-3">
             <h3 className="text-sm font-semibold">{selectedSection.label}</h3>
             <HandoffSectionContent section={selectedSection} />
@@ -503,7 +471,11 @@ const DesignStudioWorkspacePanel = memo(({
   };
 
   return (
-    <div className="mb-5 overflow-hidden rounded-xl border border-violet-500/20 bg-background">
+    <div
+      className="mb-5 overflow-hidden rounded-xl border border-violet-500/20 bg-background"
+      role="region"
+      aria-label="Design Studio workspace"
+    >
       <div className="border-b bg-muted/40 px-4 py-3">
         <div className="flex items-start justify-between gap-3 flex-wrap">
           <div>
@@ -538,7 +510,10 @@ const DesignStudioWorkspacePanel = memo(({
 
       <div className="space-y-4 p-4">
         {workspace.hasPartialFailures && (
-          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-900 dark:text-amber-100">
+          <div
+            className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-900 dark:text-amber-100"
+            role="alert"
+          >
             <div className="mb-2 flex items-center gap-2 font-semibold">
               <AlertTriangle className="h-4 w-4" />
               Partial run
@@ -554,7 +529,10 @@ const DesignStudioWorkspacePanel = memo(({
         )}
 
         {workspace.status === 'empty' ? (
-          <div className="rounded-lg border border-dashed bg-muted/20 p-4 text-sm text-muted-foreground">
+          <div
+            className="rounded-lg border border-dashed bg-muted/20 p-4 text-sm text-muted-foreground"
+            aria-live="polite"
+          >
             No candidate directions have arrived yet.
           </div>
         ) : (
@@ -654,6 +632,11 @@ const DesignStudioWorkspacePanel = memo(({
                               size="sm"
                               onClick={() => handleApprove(card.id)}
                               disabled={isApproved || Boolean(approvingDirectionId)}
+                              aria-label={
+                                isApproved
+                                  ? `${card.label} approved for refinement`
+                                  : `Approve ${card.label} for refinement`
+                              }
                             >
                               <CheckCircle2 className={cn('mr-1 h-3.5 w-3.5', isApproving && 'animate-pulse')} />
                               {isApproved ? 'Approved for Refinement' : isApproving ? 'Approving...' : 'Approve Direction'}

--- a/frontend/src/lib/designStudioHandoff.js
+++ b/frontend/src/lib/designStudioHandoff.js
@@ -1,0 +1,66 @@
+export const DESIGN_HANDOFF_KEYS = [
+  'rationale',
+  'component_map',
+  'handoff_notes',
+  'state_notes',
+  'platform_constraints',
+  'open_questions',
+];
+
+const EMPTY_LIST = [];
+
+export const getDesignStudioHandoffSection = (handoff, key) => {
+  const directSection = handoff?.[key];
+  if (directSection && typeof directSection === 'object') {
+    return {
+      label: directSection.label || key,
+      content: typeof directSection.content === 'string' ? directSection.content : '',
+      items: Array.isArray(directSection.items) ? directSection.items : EMPTY_LIST,
+    };
+  }
+
+  const section = Array.isArray(handoff?.sections)
+    ? handoff.sections.find((item) => item?.key === key)
+    : null;
+  if (!section) return null;
+
+  return {
+    label: section.label || key,
+    content: typeof section.content === 'string' ? section.content : '',
+    items: Array.isArray(section.items) ? section.items : EMPTY_LIST,
+  };
+};
+
+export const hasDesignStudioHandoffSectionContent = (section) => (
+  Boolean(section && (section.content.trim() || section.items.length > 0))
+);
+
+export const buildDesignStudioHandoffView = (handoff) => {
+  if (!handoff || handoff.status !== 'ready') {
+    return {
+      selectedRef: null,
+      selectedSection: null,
+      sections: EMPTY_LIST,
+      hasContent: false,
+    };
+  }
+
+  const selectedRef = handoff.selected_direction_ref && typeof handoff.selected_direction_ref === 'object'
+    ? handoff.selected_direction_ref
+    : null;
+  const selectedSection = getDesignStudioHandoffSection(handoff, 'selected_direction');
+  const sections = DESIGN_HANDOFF_KEYS
+    .map((key) => getDesignStudioHandoffSection(handoff, key))
+    .filter(hasDesignStudioHandoffSectionContent);
+
+  return {
+    selectedRef,
+    selectedSection,
+    sections,
+    hasContent: Boolean(
+      selectedRef ||
+      hasDesignStudioHandoffSectionContent(selectedSection) ||
+      sections.length > 0
+    ),
+  };
+};

--- a/frontend/src/lib/designStudioHandoff.test.js
+++ b/frontend/src/lib/designStudioHandoff.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  buildDesignStudioHandoffView,
+  getDesignStudioHandoffSection,
+  hasDesignStudioHandoffSectionContent,
+} from './designStudioHandoff.js';
+
+describe('designStudioHandoff', () => {
+  it('builds a renderable handoff view with state and platform sections', () => {
+    const view = buildDesignStudioHandoffView({
+      status: 'ready',
+      selected_direction_ref: {
+        id: 'direction-b',
+        label: 'Direction B',
+        source_model: 'model-b',
+        summary: 'A guided workspace.',
+      },
+      selected_direction: {
+        label: 'Selected Direction',
+        content: 'Direction B is approved.',
+        items: [],
+      },
+      rationale: {
+        label: 'Rationale',
+        content: '- Better scan path.',
+        items: ['Better scan path.'],
+      },
+      state_notes: {
+        label: 'State Notes',
+        content: '- Empty state is explicit.',
+        items: ['Empty state is explicit.'],
+      },
+      platform_constraints: {
+        label: 'Platform Constraints',
+        content: '- iOS actions stay thumb reachable.',
+        items: ['iOS actions stay thumb reachable.'],
+      },
+    });
+
+    assert.strictEqual(view.hasContent, true);
+    assert.strictEqual(view.selectedRef.label, 'Direction B');
+    assert.strictEqual(view.selectedSection.content, 'Direction B is approved.');
+    assert.deepStrictEqual(
+      view.sections.map((section) => section.label),
+      ['Rationale', 'State Notes', 'Platform Constraints']
+    );
+  });
+
+  it('normalizes legacy sections array entries', () => {
+    const section = getDesignStudioHandoffSection({
+      sections: [
+        {
+          key: 'component_map',
+          label: 'Component Map',
+          content: '',
+          items: ['Workspace: split comparison layout.'],
+        },
+      ],
+    }, 'component_map');
+
+    assert.strictEqual(section.label, 'Component Map');
+    assert.deepStrictEqual(section.items, ['Workspace: split comparison layout.']);
+    assert.strictEqual(hasDesignStudioHandoffSectionContent(section), true);
+  });
+
+  it('treats pending or empty handoffs as non-renderable', () => {
+    assert.strictEqual(buildDesignStudioHandoffView({ status: 'pending' }).hasContent, false);
+    assert.strictEqual(buildDesignStudioHandoffView({ status: 'ready' }).hasContent, false);
+  });
+});

--- a/frontend/src/lib/designStudioWorkspace.test.js
+++ b/frontend/src/lib/designStudioWorkspace.test.js
@@ -14,6 +14,17 @@ describe('designStudioWorkspace', () => {
     assert.strictEqual(view.selectedCard, null);
   });
 
+  it('keeps empty candidate arrays explicit instead of producing blank panels', () => {
+    const view = buildDesignStudioWorkspaceView({
+      candidate_directions: [],
+      comparison: { status: 'pending' },
+    });
+
+    assert.strictEqual(view.status, 'empty');
+    assert.strictEqual(view.hasComparison, false);
+    assert.deepStrictEqual(view.failedVariants, []);
+  });
+
   it('handles one pending candidate without comparison data', () => {
     const view = buildDesignStudioWorkspaceView({
       candidate_directions: [
@@ -97,6 +108,21 @@ describe('designStudioWorkspace', () => {
     assert.strictEqual(view.hasPartialFailures, true);
     assert.deepStrictEqual(view.failedVariants, [{ model: 'model-c', error: 'timeout' }]);
     assert.deepStrictEqual(view.candidateCards[0].criteria, []);
+  });
+
+  it('keeps pending comparison states operable with multiple variants', () => {
+    const view = buildDesignStudioWorkspaceView({
+      candidate_directions: [
+        { id: 'direction-a', label: 'Direction A', source_model: 'model-a' },
+        { id: 'direction-b', label: 'Direction B', source_model: 'model-b' },
+      ],
+      comparison: { status: 'pending' },
+    });
+
+    assert.strictEqual(view.status, 'pending');
+    assert.strictEqual(view.hasComparison, true);
+    assert.strictEqual(view.candidateCards.length, 2);
+    assert.strictEqual(view.selectedDirectionId, 'direction-a');
   });
 
   it('formats numeric scores for compact UI labels', () => {


### PR DESCRIPTION
## Summary
- add tested Design Studio handoff view-model normalization for selected direction, state notes, platform constraints, and legacy sections arrays
- broaden workspace view-model tests for empty candidate arrays, pending comparison with multiple variants, and partial failure states
- add accessibility semantics to Design Studio workspace and handoff panels, including labeled regions, partial-run alert role, polite empty state, and direction-specific approve button labels

## Validation
- `cd frontend && npm run test -- --run` -> 37 passed
- `cd frontend && npm run lint` -> passed
- `cd frontend && npm run build` -> passed, existing large chunk warning
- Browser QA desktop/mobile: workspace and handoff regions present; partial failure exposed as alert; approve labels present; Tab reaches visible buttons; mobile nonblank; no console errors

## Review/Security
- frontend rendering and test coverage only; no API, auth, storage, credential, or unsafe HTML behavior changed
