### PR TITLE
AR-108: Add Design Studio rollout observability

### DIFF
--- a/Info/design-studio-v1-runbook.md
+++ b/Info/design-studio-v1-runbook.md
@@ -1,0 +1,72 @@
+# Design Studio v1 Runbook
+
+## Scope
+
+Design Studio v1 supports product design exploration inside the existing Council conversation flow:
+
+- create web, iOS, or mixed Design Studio sessions
+- attach relevant source artifacts
+- generate candidate directions
+- compare and rank variants
+- approve one direction for refinement
+- export an implementation-oriented `DESIGN.md` handoff
+
+## Observability
+
+Backend streaming runs persist `design_studio_observability` metadata on Design Studio assistant turns. Use it before reading raw model output.
+
+Key fields:
+
+- `design_target`: normalized target (`web_app`, `ios_app`, or `mixed`)
+- `studio_goal`: normalized workflow goal
+- `approved_direction_id`: approved direction when one exists
+- `candidate_count`: number of viable Stage 1 directions
+- `comparison_status`: `pending` or `complete`
+- `ranked_direction_count`: number of ranked variants from Stage 2
+- `selected_direction_id`: current winning direction
+- `handoff_status`: `pending` or `ready`
+- `partial_failure_count`: Stage 1 model failures kept in the turn
+- `degraded_model_selection`: whether attached artifacts forced a degraded model-selection path
+- `requested_model_count`, `effective_model_count`, `responded_model_count`
+- `timing`: stage and total durations
+
+Streaming logs also emit `[design-studio]` lines for Stage 1, Stage 2, and Stage 3 with candidate counts, comparison status, handoff status, partial failures, degraded selection, selected direction, and duration.
+
+## Triage
+
+Blank or empty workspace:
+
+- Check `candidate_count`.
+- If it is `0`, inspect `partial_failure_count` and `stage1_errors`.
+- If model selection was degraded, inspect `degraded_model_selection` and `model_selection.warnings`.
+
+Comparison missing:
+
+- Check `comparison_status`.
+- `pending` with multiple candidates means Stage 2 did not complete or was skipped.
+- Check `ranked_direction_count` before reading the Stage 2 raw ranking text.
+
+Handoff missing:
+
+- Check `handoff_status`.
+- `pending` means Stage 3 did not produce a parseable final handoff yet.
+- Confirm the session reached a handoff/refinement goal and that the chairman response used the expected section headings.
+
+Approval/refinement issues:
+
+- Check `approved_direction_id` in both `session_config` and `design_studio_observability`.
+- The approve endpoint only accepts known candidate IDs when candidate metadata exists.
+
+## Guardrails
+
+- Design Studio metadata is only attached to `design_studio` sessions.
+- Visual critique surfaces are enabled for Design Studio only when configured goals and artifact findings justify them.
+- `DESIGN.md` export is only available through the authenticated conversation export endpoint and rejects non-Design Studio sessions.
+- If an approved direction differs from an older synthesis winner, the handoff export uses the approved candidate summary instead of stale winner sections.
+
+## Non-Goals
+
+- v1 does not auto-generate production UI code from a handoff.
+- v1 does not guarantee every selected model is vision-capable; degraded model selection is explicit metadata.
+- v1 does not persist separate normalized Design Studio tables.
+- v1 does not replace full design QA; browser and human review remain required before shipping generated handoffs.

--- a/backend/main.py
+++ b/backend/main.py
@@ -560,6 +560,49 @@ def _get_design_studio_candidate_ids(conversation: Dict[str, Any]) -> set[str]:
     return candidate_ids
 
 
+def _build_design_studio_observability_metadata(
+    *,
+    conversation: Dict[str, Any],
+    design_studio_metadata: Optional[Dict[str, Any]],
+    stage1_errors: Optional[List[Dict[str, Any]]] = None,
+    model_selection_metadata: Optional[Dict[str, Any]] = None,
+    requested_models: Optional[List[str]] = None,
+    effective_models: Optional[List[str]] = None,
+    responded_models: Optional[List[str]] = None,
+    timing: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    if normalize_session_type(conversation.get("session_type")) != "design_studio":
+        return {}
+
+    session_config = normalize_session_config(
+        conversation.get("session_config"),
+        session_type="design_studio",
+    )
+    design_studio = design_studio_metadata if isinstance(design_studio_metadata, dict) else {}
+    comparison = design_studio.get("comparison") if isinstance(design_studio.get("comparison"), dict) else {}
+    handoff = design_studio.get("handoff") if isinstance(design_studio.get("handoff"), dict) else {}
+    candidates = design_studio.get("candidate_directions")
+    ranked_directions = comparison.get("ranked_directions")
+
+    return {
+        "schema_version": 1,
+        "design_target": session_config.get("design_target"),
+        "studio_goal": session_config.get("studio_goal"),
+        "approved_direction_id": session_config.get("approved_direction_id"),
+        "candidate_count": len(candidates) if isinstance(candidates, list) else 0,
+        "comparison_status": comparison.get("status") or "pending",
+        "ranked_direction_count": len(ranked_directions) if isinstance(ranked_directions, list) else 0,
+        "selected_direction_id": design_studio.get("selected_direction_id"),
+        "handoff_status": handoff.get("status") or "pending",
+        "partial_failure_count": len(stage1_errors or []),
+        "degraded_model_selection": bool((model_selection_metadata or {}).get("degraded")),
+        "requested_model_count": len(requested_models or []),
+        "effective_model_count": len(effective_models or []),
+        "responded_model_count": len(responded_models or []),
+        "timing": timing or {},
+    }
+
+
 def _visual_review_requires_vision_models(conversation: Dict[str, Any], effective_models: List[str]) -> None:
     if normalize_session_type(conversation.get("session_type")) == "visual_review" and not effective_models:
         raise HTTPException(
@@ -1836,11 +1879,32 @@ async def send_message_stream(
             }
             if design_studio_metadata:
                 stage1_meta["design_studio"] = design_studio_metadata
+                stage1_meta["design_studio_observability"] = _build_design_studio_observability_metadata(
+                    conversation=conversation,
+                    design_studio_metadata=design_studio_metadata,
+                    stage1_errors=stage1_errors,
+                    model_selection_metadata=model_selection_metadata,
+                    requested_models=requested_council_models,
+                    effective_models=effective_council_models,
+                    responded_models=responded_council_models,
+                    timing={"stage1_seconds": stage1_duration},
+                )
             yield f"data: {json.dumps({'type': 'stage1_complete', 'data': stage1_results, 'metadata': stage1_meta})}\n\n"
             logger.info(
                 f"[stream] conversation={conversation_id} stage1_complete duration={stage1_duration}s "
                 f"responded={responded_council_models} errors={len(stage1_errors)}"
             )
+            if design_studio_metadata:
+                logger.info(
+                    "[design-studio] conversation=%s stage=stage1 target=%s goal=%s candidates=%s partial_failures=%s degraded=%s duration=%ss",
+                    conversation_id,
+                    stage1_meta["design_studio_observability"]["design_target"],
+                    stage1_meta["design_studio_observability"]["studio_goal"],
+                    stage1_meta["design_studio_observability"]["candidate_count"],
+                    stage1_meta["design_studio_observability"]["partial_failure_count"],
+                    stage1_meta["design_studio_observability"]["degraded_model_selection"],
+                    stage1_duration,
+                )
 
             if not stage1_results:
                 yield f"data: {json.dumps({'type': 'error', 'error': 'All selected models failed to respond. Please check your OpenRouter permissions or model availability.'})}\n\n"
@@ -1953,6 +2017,28 @@ async def send_message_stream(
                 f"[stream] conversation={conversation_id} stage2_complete duration={stage2_duration}s "
                 f"framework={framework}"
             )
+            if design_stage_meta:
+                design_stage_observability = _build_design_studio_observability_metadata(
+                    conversation=conversation,
+                    design_studio_metadata=design_stage_meta,
+                    stage1_errors=stage1_errors,
+                    model_selection_metadata=model_selection_metadata,
+                    requested_models=requested_council_models,
+                    effective_models=effective_council_models,
+                    responded_models=responded_council_models,
+                    timing={
+                        "stage1_seconds": stage1_duration,
+                        "stage2_seconds": stage2_duration,
+                    },
+                )
+                logger.info(
+                    "[design-studio] conversation=%s stage=stage2 comparison=%s ranked=%s selected=%s duration=%ss",
+                    conversation_id,
+                    design_stage_observability["comparison_status"],
+                    design_stage_observability["ranked_direction_count"],
+                    design_stage_observability["selected_direction_id"],
+                    stage2_duration,
+                )
 
             execution_report = await _run_code_execution_for_conversation(
                 conversation,
@@ -2008,6 +2094,7 @@ async def send_message_stream(
                 aggregate_rankings=aggregate_rankings,
                 aggregate_rubrics=aggregate_rubrics,
             )
+            stage3_duration = round(time.monotonic() - stage3_start, 3)
             stage3_metadata = {"design_studio": design_stage_meta} if design_stage_meta else {}
             stage3_metadata["session_type"] = conversation.get("session_type", DEFAULT_SESSION_TYPE)
             stage3_metadata["session_config"] = normalize_session_config(
@@ -2022,9 +2109,31 @@ async def send_message_stream(
                 visual_findings,
             )
             stage3_metadata["visual_findings"] = visual_findings
+            if design_stage_meta:
+                stage3_metadata["design_studio_observability"] = _build_design_studio_observability_metadata(
+                    conversation=conversation,
+                    design_studio_metadata=design_stage_meta,
+                    stage1_errors=stage1_errors,
+                    model_selection_metadata=model_selection_metadata,
+                    requested_models=requested_council_models,
+                    effective_models=effective_council_models,
+                    responded_models=responded_council_models,
+                    timing={
+                        "stage1_seconds": stage1_duration,
+                        "stage2_seconds": stage2_duration,
+                        "stage3_seconds": stage3_duration,
+                    },
+                )
             yield f"data: {json.dumps({'type': 'stage3_complete', 'data': stage3_result, 'metadata': stage3_metadata})}\n\n"
-            stage3_duration = round(time.monotonic() - stage3_start, 3)
             logger.info(f"[stream] conversation={conversation_id} stage3_complete duration={stage3_duration}s")
+            if design_stage_meta:
+                logger.info(
+                    "[design-studio] conversation=%s stage=stage3 handoff=%s selected=%s duration=%ss",
+                    conversation_id,
+                    stage3_metadata["design_studio_observability"]["handoff_status"],
+                    stage3_metadata["design_studio_observability"]["selected_direction_id"],
+                    stage3_duration,
+                )
 
             # Wait for title generation if it was started
             if title_task:
@@ -2075,6 +2184,16 @@ async def send_message_stream(
             }
             if design_stage_meta:
                 metadata["design_studio"] = design_stage_meta
+                metadata["design_studio_observability"] = _build_design_studio_observability_metadata(
+                    conversation=conversation,
+                    design_studio_metadata=design_stage_meta,
+                    stage1_errors=stage1_errors,
+                    model_selection_metadata=model_selection_metadata,
+                    requested_models=requested_council_models,
+                    effective_models=effective_council_models,
+                    responded_models=responded_council_models,
+                    timing=metadata["timing"],
+                )
             if framework == "heterogeneous":
                 metadata["model_weight_profile"] = serialize_model_weight_profile(
                     updated_model_profiles,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,22 @@ import { Moon, Sun, Menu, LogOut, ListTree } from "lucide-react";
 const Login = lazy(() => import('./components/Login'));
 import { useAuth } from './contexts/AuthContextDefinition';
 
+const logDesignStudioStreamMetadata = (stage, metadata) => {
+  const observability = metadata?.design_studio_observability;
+  if (!observability) return;
+
+  logger.info('[design-studio]', {
+    stage,
+    candidateCount: observability.candidate_count,
+    comparisonStatus: observability.comparison_status,
+    handoffStatus: observability.handoff_status,
+    partialFailureCount: observability.partial_failure_count,
+    degradedModelSelection: observability.degraded_model_selection,
+    selectedDirectionId: observability.selected_direction_id,
+    timing: observability.timing,
+  });
+};
+
 function App() {
   const { user, isLoading: authLoading, logout } = useAuth();
   const { toast } = useToast();
@@ -299,6 +315,7 @@ function App() {
             });
             break;
           case 'stage1_complete':
+            logDesignStudioStreamMetadata('stage1', event.metadata);
             setCurrentConversation((prev) => {
               const messages = [...prev.messages];
               const lastIndex = messages.length - 1;
@@ -324,6 +341,7 @@ function App() {
             });
             break;
           case 'stage2_complete':
+            logDesignStudioStreamMetadata('stage2', event.metadata);
             setCurrentConversation((prev) => {
               const messages = [...prev.messages];
               const lastIndex = messages.length - 1;
@@ -367,6 +385,7 @@ function App() {
             });
             break;
           case 'stage3_complete':
+            logDesignStudioStreamMetadata('stage3', event.metadata);
             setCurrentConversation((prev) => {
               const messages = [...prev.messages];
               const lastIndex = messages.length - 1;
@@ -420,6 +439,7 @@ function App() {
             setIsLoading(false);
             break;
           case 'stage2_skipped':
+            logDesignStudioStreamMetadata('stage2_skipped', event.metadata);
             setCurrentConversation((prev) => {
               const messages = [...prev.messages];
               const lastIndex = messages.length - 1;

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -923,12 +923,17 @@ Use existing workspace primitives.
             stage3_complete = next(event for event in events if event["type"] == "stage3_complete")
 
             stage1_design = stage1_complete["metadata"]["design_studio"]
+            stage1_observability = stage1_complete["metadata"]["design_studio_observability"]
             assert [item["id"] for item in stage1_design["candidate_directions"]] == [
                 "direction-a",
                 "direction-b",
             ]
             assert stage1_design["comparison"]["status"] == "pending"
             assert stage1_complete["metadata"]["session_config"] == conversation["session_config"]
+            assert stage1_observability["schema_version"] == 1
+            assert stage1_observability["candidate_count"] == 2
+            assert stage1_observability["comparison_status"] == "pending"
+            assert stage1_observability["timing"]["stage1_seconds"] >= 0
 
             stage2_design = stage2_complete["metadata"]["design_studio"]
             assert stage2_design["comparison"]["status"] == "complete"
@@ -938,8 +943,15 @@ Use existing workspace primitives.
             assert stage2_design["selected_direction_id"] == "direction-b"
 
             stage3_design = stage3_complete["metadata"]["design_studio"]
+            stage3_observability = stage3_complete["metadata"]["design_studio_observability"]
             assert stage3_design["handoff"]["status"] == "ready"
             assert stage3_design["handoff"]["selected_direction_id"] == "direction-b"
+            assert stage3_observability["comparison_status"] == "complete"
+            assert stage3_observability["handoff_status"] == "ready"
+            assert stage3_observability["selected_direction_id"] == "direction-b"
+            assert stage3_observability["partial_failure_count"] == 0
+            assert stage3_observability["degraded_model_selection"] is False
+            assert stage3_observability["timing"]["stage3_seconds"] >= 0
             assert [section["key"] for section in stage3_design["handoff"]["sections"]] == [
                 "selected_direction",
                 "rationale",
@@ -959,6 +971,8 @@ Use existing workspace primitives.
             saved_metadata = mock_add_assistant_message.await_args.args[5]
             assert saved_metadata["design_studio"]["selected_direction_id"] == "direction-b"
             assert saved_metadata["design_studio"]["handoff"]["status"] == "ready"
+            assert saved_metadata["design_studio_observability"]["candidate_count"] == 2
+            assert saved_metadata["design_studio_observability"]["timing"]["total_seconds"] >= 0
             assert saved_metadata["session_type"] == "design_studio"
             assert saved_metadata["session_config"] == conversation["session_config"]
     finally:


### PR DESCRIPTION
## Summary
- add compact `design_studio_observability` metadata for Design Studio stream events and persisted assistant turns
- log Design Studio stage summaries for Stage 1, Stage 2, and Stage 3 without requiring raw model-output scraping
- surface frontend dev logs from the same observability metadata when stream events arrive
- document v1 scope, triage fields, guardrails, and non-goals in `Info/design-studio-v1-runbook.md`

## Validation
- `uv run pytest tests/test_api.py::test_send_message_stream_design_studio_emits_structured_stage_metadata tests/test_api.py::test_send_message_design_studio_with_images_degrades_when_no_vision_models tests/test_api.py::test_export_design_handoff_markdown -q` -> 3 passed
- `uv run pytest -q` -> 196 passed, 4 existing OpenRouter mock warnings
- `cd frontend && npm run lint` -> passed
- `cd frontend && npm run test -- --run` -> 37 passed
- `cd frontend && npm run build` -> passed, existing large chunk warning

## Review/Security
- metadata is derived from existing session config, stage counts, model-selection flags, and timing; no raw model text or credentials are logged
- no auth, storage authorization, or export access behavior changed
